### PR TITLE
Reduce Kraken OHLCV pressure and add ccxt retry/backoff

### DIFF
--- a/core/market_decision_lab/scenarios.py
+++ b/core/market_decision_lab/scenarios.py
@@ -29,9 +29,10 @@ def _select_best(candidates: list[dict], key: Callable[[dict], Any], reverse: bo
 def run_scenarios(exchange: str, symbol: str, days: int, initial_cash: float, base_params: dict | None = None) -> dict:
     base_params = base_params or {}
     candidates = []
+    timeframe_data = {timeframe: fetch_ohlcv(exchange, symbol, timeframe, days) for timeframe in ["1h", "4h", "1d"]}
 
     for timeframe, ema_window, signal_mode in product(["1h", "4h", "1d"], [20, 50], ["strict", "relaxed"]):
-        ohlcv_df = fetch_ohlcv(exchange, symbol, timeframe, days)
+        ohlcv_df = timeframe_data[timeframe]
         params = BacktestParams(
             ema_window=ema_window,
             signal_mode=signal_mode,


### PR DESCRIPTION
### Motivation
- The scenarios sweep called `fetch_ohlcv` repeatedly inside a nested loop causing 12 HTTP requests per run, which triggers Kraken/ccxt rate limits on shared Streamlit Cloud IPs.
- Network errors and DDoS/RateLimit responses need resilient handling to avoid app crashes during transient failures.

### Description
- `core/market_decision_lab/scenarios.py`: Pre-fetch OHLCV once per timeframe by building `timeframe_data = {timeframe: fetch_ohlcv(...) for timeframe in ["1h","4h","1d"]}` and reuse the DataFrame in the scenario loop so OHLCV calls drop from 12 to 3.
- `core/market_decision_lab/data.py`: Configure exchange instances with `enableRateLimit=True`, `timeout=30000`, and `options.adjustForTimeDifference=True` to better cooperate with ccxt and exchanges.
- `core/market_decision_lab/data.py`: Add `_with_retry` wrapper that retries `ccxt.DDoSProtection`, `ccxt.RateLimitExceeded`, and `ccxt.NetworkError` with exponential backoff (starting at 1s, doubling) and `max_attempts=5`, and apply it to `load_markets` and `fetch_ohlcv` calls.
- Keep all strings ASCII-only and avoid behavioral changes beyond reducing duplicate HTTP calls and adding retry/backoff.

### Testing
- Ran `python -m compileall core/market_decision_lab` which succeeded.
- Attempted an end-to-end `run_scenarios` call which failed due to the environment having no external network (error contacting `api.kraken.com`), indicating the failure was environmental and not a code regression.
- Verified the reduced-call behavior by monkeypatching `fetch_ohlcv` in a smoke test, which showed exactly 3 fetch calls and produced 12 candidates.
- Validated retry/backoff logic using a fake exchange class that simulated transient `NetworkError`/`RateLimitExceeded` failures; the function retried and eventually returned expected OHLCV rows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698710d42b60832882455b94ae0c6b2b)