### PR TITLE
Add CSV log store and in-app log download exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Market Decision Lab is a Streamlit decision-support application for evaluating w
 - Computes performance and risk metrics.
 - Produces a decision label: **INVEST**, **CAUTION**, or **NO**.
 - Stores run and trade history in SQLite at `data/app.db`.
+- Collects production-friendly CSV logs for run audits and diagnostics.
 
 ## Repository structure
 - `app/streamlit_app.py` - Streamlit entrypoint.
-- `core/market_decision_lab/` - Core backtest, data, metrics, decision, scenario, and storage logic.
+- `app/pages/Logs.py` - Streamlit page for downloading log CSVs and ZIP bundles.
+- `core/market_decision_lab/` - Core backtest, data, metrics, decision, scenario, storage, and logging logic.
 - `data/` - SQLite database directory created at runtime.
+- `app/data/logs/` - Default CSV log directory.
 - `export_data.py` - Script to export runs and trades data to CSV files.
 - `requirements.txt` - Python dependencies.
 
@@ -27,6 +30,25 @@ Market Decision Lab is a Streamlit decision-support application for evaluating w
 pip install -r requirements.txt
 streamlit run app/streamlit_app.py
 ```
+
+## Log collection and export
+The app writes audit-friendly CSV logs to `app/data/logs` by default (override with `MDL_LOG_DIR`).
+
+Collected files:
+- `runs.csv` with run-level records (status, latency, rate-limit hits, params, metrics, decision).
+- `events.csv` with stage-level lifecycle events (for example UI submit, data fetch, and decision evaluation).
+- `errors.csv` with exception summaries and trimmed tracebacks.
+- `app_health.csv` is reserved for optional health metrics.
+
+How to download logs:
+1. Open the **Logs** page in the Streamlit app.
+2. Use download buttons for `runs.csv`, `events.csv`, and `errors.csv`.
+3. Use the ZIP button to download all existing log files as one archive.
+
+Privacy notes:
+- Sensitive metadata keys are removed before writing logs (for example API keys, tokens, authorization headers, cookies, and IP fields).
+- Very long string values are truncated before persistence.
+- Do not add secrets to user input fields.
 
 ## Export data
 To export the runs and trades data from the SQLite database to CSV files:

--- a/app/pages/Logs.py
+++ b/app/pages/Logs.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+ROOT = Path(__file__).resolve().parents[2]
+CORE_PATH = ROOT / "core"
+if str(CORE_PATH) not in sys.path:
+    sys.path.insert(0, str(CORE_PATH))
+
+from market_decision_lab.log_store import CsvLogStore
+
+st.set_page_config(page_title="Logs", layout="wide")
+st.title("Logs")
+st.caption("Download run logs and diagnostics collected by the app.")
+
+log_dir = Path(os.getenv("MDL_LOG_DIR", "app/data/logs"))
+if not log_dir.is_absolute():
+    log_dir = ROOT / log_dir
+
+store = CsvLogStore(str(log_dir))
+
+runs_df = store.read_csv("runs")
+
+total_runs = int(len(runs_df))
+failures_24h = 0
+last_run = "N/A"
+p95_latency = "N/A"
+
+if not runs_df.empty and "run_ts" in runs_df.columns:
+    now_utc = pd.Timestamp.utcnow().tz_convert("UTC")
+    failures_24h = int(((runs_df["status"] == "fail") & (runs_df["run_ts"] >= (now_utc - pd.Timedelta(hours=24)))).sum())
+    valid_run_ts = runs_df["run_ts"].dropna()
+    if not valid_run_ts.empty:
+        last_run = valid_run_ts.max().strftime("%Y-%m-%d %H:%M:%S UTC")
+
+if not runs_df.empty and "latency_ms" in runs_df.columns:
+    valid_latency = pd.to_numeric(runs_df["latency_ms"], errors="coerce").dropna()
+    if not valid_latency.empty:
+        p95_latency = f"{int(valid_latency.quantile(0.95))} ms"
+
+c1, c2, c3, c4 = st.columns(4)
+c1.metric("Total runs", total_runs)
+c2.metric("Failures (last 24h)", failures_24h)
+c3.metric("Last run", last_run)
+c4.metric("P95 latency", p95_latency)
+
+st.divider()
+
+
+def get_csv_bytes(name: str) -> bytes | None:
+    file_path = store.files[name]
+    if not file_path.exists():
+        return None
+    return file_path.read_bytes()
+
+
+for csv_name in ["runs", "events", "errors"]:
+    payload = get_csv_bytes(csv_name)
+    if payload is None:
+        st.info(f"{csv_name}.csv is not available yet.")
+    st.download_button(
+        f"Download {csv_name}.csv",
+        data=payload or b"",
+        file_name=f"{csv_name}.csv",
+        mime="text/csv",
+        disabled=payload is None,
+        use_container_width=True,
+    )
+
+bundle = store.bundle_zip()
+if not bundle:
+    st.info("No log files available yet for a ZIP export.")
+
+st.download_button(
+    "Download logs bundle (.zip)",
+    data=bundle,
+    file_name="logs_bundle.zip",
+    mime="application/zip",
+    disabled=not bool(bundle),
+    use_container_width=True,
+)

--- a/core/market_decision_lab/log_store.py
+++ b/core/market_decision_lab/log_store.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+SENSITIVE_KEYS = {
+    "api_key",
+    "apikey",
+    "key",
+    "secret",
+    "token",
+    "authorization",
+    "auth",
+    "cookie",
+    "cookies",
+    "set-cookie",
+    "ip",
+    "x-forwarded-for",
+}
+
+RUN_FIELDS = [
+    "run_id",
+    "run_ts",
+    "exchange",
+    "symbol",
+    "timeframe",
+    "days",
+    "status",
+    "latency_ms",
+    "rate_limit_hits",
+    "params_json",
+    "metrics_json",
+    "decision_json",
+]
+
+EVENT_FIELDS = [
+    "event_ts",
+    "run_id",
+    "level",
+    "stage",
+    "message",
+    "duration_ms",
+    "meta_json",
+]
+
+ERROR_FIELDS = [
+    "error_ts",
+    "run_id",
+    "exc_type",
+    "exc_message",
+    "traceback_short",
+    "context_json",
+]
+
+APP_HEALTH_FIELDS = ["event_ts", "key", "value", "meta_json"]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def sanitize_meta(meta: dict) -> dict:
+    sanitized: dict = {}
+    for key, value in (meta or {}).items():
+        key_lower = str(key).lower()
+        if key_lower in SENSITIVE_KEYS:
+            continue
+
+        if isinstance(value, dict):
+            sanitized[key] = sanitize_meta(value)
+            continue
+
+        if isinstance(value, list):
+            sanitized[key] = [sanitize_meta(v) if isinstance(v, dict) else _truncate_value(v) for v in value]
+            continue
+
+        sanitized[key] = _truncate_value(value)
+
+    return sanitized
+
+
+def _truncate_value(value):
+    if isinstance(value, str) and len(value) > 200:
+        return f"{value[:20]}..."
+    return value
+
+
+class CsvLogStore:
+    def __init__(self, base_dir: str):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.files = {
+            "runs": self.base_dir / "runs.csv",
+            "events": self.base_dir / "events.csv",
+            "errors": self.base_dir / "errors.csv",
+            "app_health": self.base_dir / "app_health.csv",
+        }
+
+    def append_run(self, row: dict) -> None:
+        self._append("runs", RUN_FIELDS, row)
+
+    def append_event(self, row: dict) -> None:
+        self._append("events", EVENT_FIELDS, row)
+
+    def append_error(self, row: dict) -> None:
+        self._append("errors", ERROR_FIELDS, row)
+
+    def read_csv(self, name: str) -> pd.DataFrame:
+        file_path = self.files.get(name)
+        if not file_path or not file_path.exists():
+            return pd.DataFrame()
+
+        df = pd.read_csv(file_path)
+        if "Unnamed: 0" in df.columns:
+            df = df.drop(columns=["Unnamed: 0"])
+        if name == "runs" and "run_ts" in df.columns:
+            df["run_ts"] = pd.to_datetime(df["run_ts"], utc=True, errors="coerce")
+        return df
+
+    def bundle_zip(self) -> bytes:
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+            for file_path in self.files.values():
+                if file_path.exists():
+                    zip_file.write(file_path, arcname=file_path.name)
+        buffer.seek(0)
+        return buffer.read()
+
+    def _append(self, name: str, fields: list[str], row: dict) -> None:
+        file_path = self.files[name]
+        payload = {field: row.get(field) for field in fields}
+        file_exists = file_path.exists()
+
+        with file_path.open("a", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fields)
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(payload)
+
+
+def to_json_str(payload: dict | list | None) -> str:
+    safe_payload = payload if payload is not None else {}
+    return json.dumps(safe_payload, ensure_ascii=False, default=str)


### PR DESCRIPTION
### Motivation
- Provide production-friendly, auditable CSV logs for runs, lifecycle events, and errors so Streamlit Cloud deployments can export and review UX, errors, and performance without changing decision logic. 
- Ensure logs are privacy-aware by removing secret-like keys and truncating very long values before persistence. 
- Make logs easily downloadable from the app UI and packaged as a ZIP for bulk export. 
- Fix CSV index artifacts and ensure `run_ts` is parsed robustly as UTC when reading logs.

### Description
- Added `core/market_decision_lab/log_store.py` implementing `CsvLogStore` with stable schemas for `runs.csv`, `events.csv`, `errors.csv`, optional `app_health.csv`, UTC timestamps, header-first append, metadata sanitization, long-value truncation, read-time `run_ts` parsing (`utc=True`, `errors='coerce'`), and an in-memory `bundle_zip()` that returns a ZIP bytes payload. 
- Integrated logging into `app/streamlit_app.py` by initializing `CsvLogStore` (configurable via `MDL_LOG_DIR`), creating `run_id` per user action, emitting stage-level events (`ui.submit`, `run.started`, `data.load_markets`, `data.fetch_ohlcv`, `decision.evaluate`, etc.), timing latencies, writing run summaries (`status` mapped to `ok|warn|fail`), and capturing errors with trimmed tracebacks and sanitized context; rate-limit hits detected heuristically (`Too many requests` / `DDoSProtection`). 
- Added Streamlit page `app/pages/Logs.py` that surfaces basic stats (total runs, failures last 24h, last run time, p95 latency) and provides download buttons for `runs.csv`, `events.csv`, `errors.csv`, and a ZIP bundle, with friendly disabled messaging if files are missing. 
- Updated `README.md` documenting collected logs, default storage location (`app/data/logs`), how to download logs from the Logs page, and privacy notes about sanitization; ensured CSV writes avoid index artifacts and reads drop `Unnamed: 0`.

### Testing
- Code compiles: `python -m compileall app core export_data.py` succeeded. 
- Module-level sanity: `python -m py_compile app/streamlit_app.py core/market_decision_lab/log_store.py` succeeded. 
- Manual smoke flow: launched the app (`streamlit run app/streamlit_app.py --server.headless true --server.port 8501`), exercised a Quick Check via a browser automation script, opened the Logs page, and captured screenshots; this exercised success and error code paths. 
- Log inspection: verified `app/data/logs` contains `runs.csv`, `events.csv`, and `errors.csv` with expected headers and no `Unnamed: 0`, and `run_ts` parsed as UTC; all checks passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987785116d88328b7ef9bf9fad9839d)