### PR TITLE
Bump Streamlit to 1.37.0 to address PYSEC-2024-153

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.36.0
+streamlit==1.37.0
 pandas==2.2.2
 numpy==1.26.4
 ccxt==4.3.97


### PR DESCRIPTION
### Motivation
- Update Streamlit to the patched `1.37.0` release to remediate the `PYSEC-2024-153` vulnerability.

### Description
- Bumped `streamlit` in `requirements.txt` from `1.36.0` to `1.37.0` and left all other pinned dependencies unchanged.

### Testing
- Attempted to install in a Python 3.10 virtualenv with `python3.10 -m venv .venv-test && source .venv-test/bin/activate && pip install -r requirements.txt` but the install was blocked by a network/proxy error (403), and separately verified `streamlit` can be imported with `python3.10 -c "import streamlit,sys; print(streamlit.__version__)"` which succeeded in the available runtime (reported `1.54.0`), so import works but full install verification could not be completed due to network restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878f4d04c8832889a8f0c12de99f73)