### PR TITLE
Fix PYTHONPATH for Streamlit Cloud deployment

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
 import json
 import os
 import sqlite3
-import sys
 import time
 import traceback
 import uuid
 from datetime import datetime, timezone
-from pathlib import Path
 
 import pandas as pd
 import streamlit as st
 
-ROOT = Path(__file__).resolve().parents[1]
 CORE_PATH = ROOT / "core"
 if str(CORE_PATH) not in sys.path:
     sys.path.insert(0, str(CORE_PATH))


### PR DESCRIPTION
### Motivation
- Streamlit Cloud does not include the repository root in `PYTHONPATH`, causing imports from `core/market_decision_lab` to fail when running the app entrypoint.

### Description
- Add a minimal bootstrap at the very top of `app/streamlit_app.py` that appends the repository root (parent of `app/`) to `sys.path` if missing, while keeping the existing `core/` insertion and all application logic unchanged.

### Testing
- Ran `streamlit run app/streamlit_app.py --server.headless true --server.port 8502` and confirmed the app process started and served on localhost without import errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987961265f88328b01130bfea44cde8)