### PR TITLE
Refine Auto Strategy Lab behavior and align API/UI with MVP spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Market Decision Lab is a Streamlit decision-support application for evaluating w
 ## Features
 - Pulls OHLCV market data through `ccxt`.
 - Runs a long-only EMA + ATR backtest.
+- Includes an **Auto Strategy Lab** that generates multiple explainable strategy candidates, backtests them, and ranks them by objective.
 - Computes performance and risk metrics.
 - Produces a decision label: **INVEST**, **CAUTION**, or **NO**.
 - Stores run and trade history in SQLite at `data/app.db`.
@@ -30,6 +31,26 @@ Market Decision Lab is a Streamlit decision-support application for evaluating w
 pip install -r requirements.txt
 streamlit run app/streamlit_app.py
 ```
+
+## Strategy Lab (Auto)
+The Strategy Lab searches through a compact library of simple long-only strategies and parameter combinations, then ranks candidates by your selected objective:
+- **Sharpe**
+- **Return**
+- **Min Drawdown**
+- **Win Rate**
+
+Included strategy families:
+- EMA Trend
+- EMA Crossover
+- RSI Mean Reversion
+- Donchian Breakout
+
+For each candidate, the app shows:
+- Human-readable strategy explanation text
+- Key metrics (return, drawdown, Sharpe, win rate, trade count)
+- Equity curve and trade table for inspection
+
+The search is intentionally capped (Streamlit Cloud friendly) to avoid long runtimes.
 
 ## Local sanity check
 ```bash

--- a/core/market_decision_lab/strategies.py
+++ b/core/market_decision_lab/strategies.py
@@ -1,0 +1,112 @@
+"""Simple explainable strategy library for Strategy Lab."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import product
+from typing import Callable
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class StrategySpec:
+    id: str
+    name: str
+    description_template: str
+    param_grid: dict[str, list]
+    build_signals: Callable[[pd.DataFrame, dict], tuple[pd.Series, pd.Series]]
+
+
+def _rsi(series: pd.Series, window: int = 14) -> pd.Series:
+    delta = series.diff()
+    gains = delta.clip(lower=0)
+    losses = (-delta).clip(lower=0)
+    avg_gain = gains.ewm(alpha=1 / window, adjust=False, min_periods=window).mean()
+    avg_loss = losses.ewm(alpha=1 / window, adjust=False, min_periods=window).mean()
+    rs = avg_gain / avg_loss.replace(0, pd.NA)
+    rsi = 100 - (100 / (1 + rs))
+    return rsi.fillna(50.0)
+
+
+def _ema_trend(df: pd.DataFrame, params: dict) -> tuple[pd.Series, pd.Series]:
+    ema = df["close"].ewm(span=int(params["ema_window"]), adjust=False).mean()
+    entry = df["close"] > ema
+    exit_ = df["close"] < ema
+    return entry.fillna(False), exit_.fillna(False)
+
+
+def _ema_crossover(df: pd.DataFrame, params: dict) -> tuple[pd.Series, pd.Series]:
+    fast = df["close"].ewm(span=int(params["fast_ema"]), adjust=False).mean()
+    slow = df["close"].ewm(span=int(params["slow_ema"]), adjust=False).mean()
+    spread = fast - slow
+    entry = (spread > 0) & (spread.shift(1) <= 0)
+    exit_ = (spread < 0) & (spread.shift(1) >= 0)
+    return entry.fillna(False), exit_.fillna(False)
+
+
+def _rsi_mean_reversion(df: pd.DataFrame, params: dict) -> tuple[pd.Series, pd.Series]:
+    rsi = _rsi(df["close"], window=int(params["rsi_window"]))
+    entry = rsi < float(params["entry_rsi"])
+    exit_ = rsi > float(params["exit_rsi"])
+    return entry.fillna(False), exit_.fillna(False)
+
+
+def _donchian_breakout(df: pd.DataFrame, params: dict) -> tuple[pd.Series, pd.Series]:
+    breakout_n = int(params["breakout_window"])
+    exit_n = int(params["exit_window"])
+    rolling_high = df["high"].rolling(window=breakout_n, min_periods=breakout_n).max().shift(1)
+    rolling_low = df["low"].rolling(window=exit_n, min_periods=exit_n).min().shift(1)
+    entry = df["close"] > rolling_high
+    exit_ = df["close"] < rolling_low
+    return entry.fillna(False), exit_.fillna(False)
+
+
+STRATEGIES: dict[str, StrategySpec] = {
+    "ema_trend": StrategySpec(
+        id="ema_trend",
+        name="EMA Trend",
+        description_template="Long when close is above EMA({ema_window}); exit when close falls below EMA({ema_window}).",
+        param_grid={"ema_window": [20, 50, 100]},
+        build_signals=_ema_trend,
+    ),
+    "ema_crossover": StrategySpec(
+        id="ema_crossover",
+        name="EMA Crossover",
+        description_template="Long when EMA({fast_ema}) crosses above EMA({slow_ema}); exit when EMA({fast_ema}) crosses below EMA({slow_ema}).",
+        param_grid={"fast_ema": [10, 20], "slow_ema": [50, 100]},
+        build_signals=_ema_crossover,
+    ),
+    "rsi_mean_reversion": StrategySpec(
+        id="rsi_mean_reversion",
+        name="RSI Mean Reversion",
+        description_template="Long when RSI({rsi_window}) is below {entry_rsi}; exit when RSI({rsi_window}) is above {exit_rsi}.",
+        param_grid={"rsi_window": [14], "entry_rsi": [25, 30], "exit_rsi": [50, 55]},
+        build_signals=_rsi_mean_reversion,
+    ),
+    "donchian_breakout": StrategySpec(
+        id="donchian_breakout",
+        name="Donchian Breakout",
+        description_template="Long when close breaks above the prior {breakout_window}-bar high; exit when close falls below the prior {exit_window}-bar low.",
+        param_grid={"breakout_window": [20, 50], "exit_window": [10, 20]},
+        build_signals=_donchian_breakout,
+    ),
+}
+
+
+def generate_candidates(max_runs: int = 160) -> list[tuple[str, dict]]:
+    """Generate deterministic (strategy_id, params) candidates capped by ``max_runs``."""
+    if max_runs < 1:
+        return []
+
+    candidates: list[tuple[str, dict]] = []
+    for strategy_id, spec in STRATEGIES.items():
+        keys = list(spec.param_grid.keys())
+        values = [spec.param_grid[key] for key in keys]
+        for combo in product(*values):
+            params = dict(zip(keys, combo))
+            candidates.append((strategy_id, params))
+            if len(candidates) >= max_runs:
+                return candidates
+
+    return candidates

--- a/core/market_decision_lab/strategy_backtest.py
+++ b/core/market_decision_lab/strategy_backtest.py
@@ -1,0 +1,188 @@
+"""Generic signal-driven backtesting engine."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .backtest import BacktestParams, _atr
+
+REQUIRED_COLUMNS = {"ts", "open", "high", "low", "close"}
+
+
+def _validate_inputs(ohlcv_df: pd.DataFrame, entry_signal: pd.Series, exit_signal: pd.Series) -> tuple[pd.DataFrame, pd.Series, pd.Series]:
+    if ohlcv_df.empty:
+        raise ValueError("Input OHLCV data is empty")
+
+    missing = REQUIRED_COLUMNS - set(ohlcv_df.columns)
+    if missing:
+        raise ValueError(f"Input OHLCV data is missing required columns: {sorted(missing)}")
+
+    if len(entry_signal) != len(ohlcv_df):
+        raise ValueError("Entry signal length must match OHLCV length")
+    if len(exit_signal) != len(ohlcv_df):
+        raise ValueError("Exit signal length must match OHLCV length")
+
+    df = ohlcv_df.copy().reset_index(drop=True)
+    entry = pd.Series(entry_signal).reset_index(drop=True)
+    exit_ = pd.Series(exit_signal).reset_index(drop=True)
+
+    if entry.isna().any() or exit_.isna().any():
+        raise ValueError("Signals must not contain NaN values")
+
+    return df, entry.astype(bool), exit_.astype(bool)
+
+
+def run_backtest_signals(
+    ohlcv_df: pd.DataFrame,
+    entry_signal: pd.Series,
+    exit_signal: pd.Series,
+    params: BacktestParams,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Run a long-only backtest driven by boolean entry/exit signals."""
+    df, entry_signal, exit_signal = _validate_inputs(ohlcv_df, entry_signal, exit_signal)
+
+    if params is None:
+        raise ValueError("params is required")
+
+    df["atr"] = _atr(df, 14)
+
+    cash = params.initial_cash
+    units = 0.0
+    in_position = False
+    cooldown = 0
+
+    entry_price_raw = np.nan
+    entry_price_cost = np.nan
+    entry_ts = None
+    sl = np.nan
+    tp = np.nan
+
+    trades: List[dict] = []
+    states: List[dict] = []
+
+    for i, row in df.iterrows():
+        ts = row["ts"]
+        open_p, high_p, low_p, close_p, atr = row["open"], row["high"], row["low"], row["close"], row["atr"]
+        action = "HOLD"
+
+        if in_position:
+            exit_price_raw = None
+            reason = None
+
+            if low_p <= sl and high_p >= tp:
+                exit_price_raw = sl
+                reason = "stop_loss"
+            elif low_p <= sl:
+                exit_price_raw = sl
+                reason = "stop_loss"
+            elif high_p >= tp:
+                exit_price_raw = tp
+                reason = "take_profit"
+            elif bool(exit_signal.iloc[i]):
+                exit_price_raw = close_p
+                reason = "signal_exit"
+
+            if exit_price_raw is not None:
+                effective_exit = exit_price_raw * (1 - params.slippage_per_side)
+                gross = units * effective_exit
+                fee = gross * params.fee_per_side
+                cash = gross - fee
+
+                pnl_pct = ((effective_exit - entry_price_cost) / entry_price_cost) * 100
+                trades.append(
+                    {
+                        "entry_ts": entry_ts,
+                        "exit_ts": ts,
+                        "entry": round(float(entry_price_raw), 8),
+                        "exit": round(float(exit_price_raw), 8),
+                        "pnl": float(units * (effective_exit - entry_price_cost)),
+                        "pnl_pct": float(pnl_pct),
+                        "reason": reason,
+                        "sl": float(sl),
+                        "tp": float(tp),
+                    }
+                )
+
+                units = 0.0
+                in_position = False
+                cooldown = params.cooldown_candles
+                action = f"EXIT:{reason}"
+
+        if (not in_position) and (cooldown <= 0) and not np.isnan(atr):
+            if bool(entry_signal.iloc[i]):
+                if params.entry_mode == "next_open":
+                    if i + 1 < len(df):
+                        signal_idx = i + 1
+                        fill_raw = float(df.loc[signal_idx, "open"])
+                        fill_ts = df.loc[signal_idx, "ts"]
+                    else:
+                        fill_raw = float(close_p)
+                        fill_ts = ts
+                else:
+                    fill_raw = float(close_p)
+                    fill_ts = ts
+
+                fill_cost = fill_raw * (1 + params.slippage_per_side)
+                trade_value = cash
+                fee = trade_value * params.fee_per_side
+                spendable = trade_value - fee
+                if spendable > 0:
+                    units = spendable / fill_cost
+                    cash = 0.0
+                    in_position = True
+                    entry_price_raw = fill_raw
+                    entry_price_cost = fill_cost
+                    entry_ts = fill_ts
+                    sl = entry_price_raw - params.sl_mult * atr
+                    tp = entry_price_raw + params.tp_mult * atr
+                    action = "ENTRY"
+
+        if cooldown > 0 and not in_position:
+            cooldown -= 1
+
+        mark_price = close_p * (1 - params.slippage_per_side) if in_position else close_p
+        equity = cash + units * mark_price
+        states.append(
+            {
+                "ts": ts,
+                "close": close_p,
+                "atr": atr,
+                "equity": equity,
+                "position": 1 if in_position else 0,
+                "action": action,
+                "sl": sl if in_position else np.nan,
+                "tp": tp if in_position else np.nan,
+            }
+        )
+
+    if in_position:
+        last = df.iloc[-1]
+        effective_exit = float(last["close"]) * (1 - params.slippage_per_side)
+        gross = units * effective_exit
+        fee = gross * params.fee_per_side
+        cash = gross - fee
+        pnl_pct = ((effective_exit - entry_price_cost) / entry_price_cost) * 100
+        trades.append(
+            {
+                "entry_ts": entry_ts,
+                "exit_ts": last["ts"],
+                "entry": round(float(entry_price_raw), 8),
+                "exit": round(float(last["close"]), 8),
+                "pnl": float(units * (effective_exit - entry_price_cost)),
+                "pnl_pct": float(pnl_pct),
+                "reason": "end_of_test",
+                "sl": float(sl),
+                "tp": float(tp),
+            }
+        )
+        states[-1]["equity"] = cash
+
+    backtest_df = pd.DataFrame(states)
+    trades_df = pd.DataFrame(
+        trades,
+        columns=["entry_ts", "exit_ts", "entry", "exit", "pnl", "pnl_pct", "reason", "sl", "tp"],
+    )
+    return backtest_df, trades_df

--- a/core/market_decision_lab/strategy_lab.py
+++ b/core/market_decision_lab/strategy_lab.py
@@ -1,0 +1,104 @@
+"""Auto Strategy Lab orchestration and ranking."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+
+from .backtest import BacktestParams
+from .strategies import STRATEGIES, generate_candidates
+from .strategy_backtest import run_backtest_signals
+
+OBJECTIVES = {
+    "Sharpe": ("sharpe", False),
+    "Return": ("total_return_pct", False),
+    "Min Drawdown": ("max_drawdown_pct", True),
+    "Win Rate": ("win_rate", False),
+}
+
+
+def _compute_strategy_metrics(backtest_df: pd.DataFrame, trades_df: pd.DataFrame, initial_cash: float) -> dict:
+    final_equity = float(backtest_df["equity"].iloc[-1]) if not backtest_df.empty else float(initial_cash)
+    total_return_pct = float(((final_equity / initial_cash) - 1) * 100)
+
+    if backtest_df.empty:
+        max_drawdown_pct = 0.0
+        sharpe = 0.0
+    else:
+        rolling_peak = backtest_df["equity"].cummax()
+        drawdown = (backtest_df["equity"] - rolling_peak) / rolling_peak.replace(0, np.nan)
+        max_drawdown_pct = abs(float(drawdown.min() * 100)) if not drawdown.isna().all() else 0.0
+
+        equity_ret = backtest_df["equity"].pct_change().dropna()
+        std = float(equity_ret.std()) if not equity_ret.empty else 0.0
+        sharpe = 0.0 if std == 0.0 else float((equity_ret.mean() / std) * math.sqrt(252))
+
+    n_trades = int(len(trades_df))
+    win_rate = float((trades_df["pnl"] > 0).mean() * 100) if n_trades else 0.0
+
+    return {
+        "total_return_pct": total_return_pct,
+        "max_drawdown_pct": max_drawdown_pct,
+        "sharpe": sharpe,
+        "win_rate": win_rate,
+        "n_trades": n_trades,
+    }
+
+
+def run_strategy_lab(
+    ohlcv_df: pd.DataFrame,
+    objective: str,
+    max_runs: int,
+    top_n: int,
+) -> tuple[pd.DataFrame, dict[str, dict]]:
+    """Run strategy candidates, rank by objective, and return top results with details."""
+    if ohlcv_df.empty:
+        raise ValueError("Input OHLCV data is empty")
+    if objective not in OBJECTIVES:
+        raise ValueError(f"Unsupported objective: {objective}. Valid options are {list(OBJECTIVES.keys())}")
+    if max_runs < 1:
+        raise ValueError("max_runs must be >= 1")
+    if top_n < 1:
+        raise ValueError("top_n must be >= 1")
+
+    params = BacktestParams()
+    rows: list[dict] = []
+    details: dict[str, dict] = {}
+
+    for idx, (strategy_id, strategy_params) in enumerate(generate_candidates(max_runs=max_runs)):
+        spec = STRATEGIES[strategy_id]
+        entry_signal, exit_signal = spec.build_signals(ohlcv_df, strategy_params)
+        backtest_df, trades_df = run_backtest_signals(ohlcv_df, entry_signal, exit_signal, params)
+        metrics = _compute_strategy_metrics(backtest_df, trades_df, params.initial_cash)
+
+        candidate_id = f"{strategy_id}__{idx}"
+        description = spec.description_template.format(**strategy_params)
+        rows.append(
+            {
+                "candidate_id": candidate_id,
+                "strategy_id": strategy_id,
+                "strategy_name": spec.name,
+                "params": strategy_params,
+                "description": description,
+                **metrics,
+            }
+        )
+        details[candidate_id] = {
+            "strategy_id": strategy_id,
+            "strategy_name": spec.name,
+            "params": strategy_params,
+            "description": description,
+            "backtest_df": backtest_df,
+            "trades_df": trades_df,
+            "metrics": metrics,
+        }
+
+    results_df = pd.DataFrame(rows)
+    sort_key, ascending = OBJECTIVES[objective]
+    ranked_df = results_df.sort_values(by=[sort_key, "total_return_pct"], ascending=[ascending, False]).reset_index(drop=True)
+    top_df = ranked_df.head(top_n).reset_index(drop=True)
+    top_ids = set(top_df["candidate_id"].tolist())
+    top_details = {candidate_id: payload for candidate_id, payload in details.items() if candidate_id in top_ids}
+    return top_df, top_details

--- a/tools/smoke_check.py
+++ b/tools/smoke_check.py
@@ -28,6 +28,9 @@ MODULES = [
     "market_decision_lab.scenarios",
     "market_decision_lab.storage",
     "market_decision_lab.log_store",
+    "market_decision_lab.strategy_backtest",
+    "market_decision_lab.strategies",
+    "market_decision_lab.strategy_lab",
 ]
 
 


### PR DESCRIPTION
### Motivation
- Provide a compact, research-only "Auto Strategy Lab" that generates simple explainable long-only strategies, backtests them deterministically, ranks candidates by a chosen objective, and surfaces human-readable rules for inspection. 
- Fix earlier behavior and align the API and Streamlit UX with the requested MVP contract (deterministic candidate capping, consistent ATR SL/TP semantics, and Streamlit-friendly runtimes). 

### Description
- Added a small strategy library at `core/market_decision_lab/strategies.py` defining `StrategySpec`, four long-only families (EMA Trend, EMA Crossover, RSI Mean Reversion, Donchian Breakout), and `generate_candidates(max_runs)` for deterministic param-grid candidate generation. 
- Added a generic signal-driven backtester at `core/market_decision_lab/strategy_backtest.py` exposing `run_backtest_signals(...)` that reuses the existing ATR SL/TP, `fee_per_side`, `slippage_per_side`, `cooldown_candles`, and `initial_cash` behaviors and validates inputs. 
- Implemented orchestration and ranking at `core/market_decision_lab/strategy_lab.py` with metrics (`total_return_pct`, `max_drawdown_pct`, `sharpe`, `win_rate`, `n_trades`) and `run_strategy_lab(df, objective, max_runs, top_n)` which returns the top-N ranked candidates and trimmed details. 
- Integrated the lab into the Streamlit UI (`app/streamlit_app.py`), adding a sidebar `Mode` selector, UI controls for `objective`/`max_runs`/`top_n`, a cached `_cached_strategy_lab(...)` call that includes `top_n`, and a Strategy Lab tab that displays the top candidates, an explanation string, equity chart, and trades table. 
- Minor doc and tooling updates: README entry for Strategy Lab and `tools/smoke_check.py` imports updated to include new modules. 

### Testing
- Compiled modified modules with `python -m py_compile app/streamlit_app.py core/market_decision_lab/strategy_backtest.py core/market_decision_lab/strategies.py core/market_decision_lab/strategy_lab.py tools/smoke_check.py` (succeeded). 
- Ran the repository sanity check with `python tools/smoke_check.py` (succeeded). 
- Performed a functional smoke test of the lab using synthetic OHLCV by calling `run_strategy_lab(..., objective='Sharpe', max_runs=30, top_n=5)` which returned top candidates and details (succeeded). 
- Launched the Streamlit app locally (`streamlit run app/streamlit_app.py`) and captured a UI screenshot to verify the new mode, controls, and Strategy Lab tab (app launched and UI render verified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879c901ee48328be144e18baa0b615)