### PR TITLE
chore: apply safe packaging and typing hygiene updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "market-decision-lab"
 version = "0.1.0"
 description = "Research-only market decision engine and Streamlit app"
+readme = "README.md"
 requires-python = ">=3.10"
 
 [tool.setuptools]

--- a/src/mdl/__init__.py
+++ b/src/mdl/__init__.py
@@ -1,5 +1,15 @@
 """Market Decision Lab internal engine package."""
 
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
 from .decision import evaluate_run, final_decision
 
-__all__ = ["evaluate_run", "final_decision"]
+try:
+    __version__ = version("market-decision-lab")
+except PackageNotFoundError:
+    # Fallback for editable/local source execution without installed package metadata.
+    __version__ = "0.1.0"
+
+__all__ = ["__version__", "evaluate_run", "final_decision"]

--- a/src/mdl/data/ohlcv.py
+++ b/src/mdl/data/ohlcv.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import math
 import random
 import time
-from typing import Dict
-
 import ccxt
 import pandas as pd
 
-TIMEFRAME_TO_MINUTES: Dict[str, int] = {"1m": 1, "5m": 5, "15m": 15, "1h": 60, "4h": 240, "1d": 1440}
+TIMEFRAME_TO_MINUTES: dict[str, int] = {"1m": 1, "5m": 5, "15m": 15, "1h": 60, "4h": 240, "1d": 1440}
 
 
 def select_symbol(exchange_name: str, asset: str, markets: dict) -> str:

--- a/src/mdl/lab/strategy_lab.py
+++ b/src/mdl/lab/strategy_lab.py
@@ -7,9 +7,8 @@ import math
 import numpy as np
 import pandas as pd
 
-from mdl.backtest.engine import BacktestParams
+from mdl.backtest.engine import BacktestParams, run_backtest_signals
 from mdl.strategies import STRATEGIES, generate_candidates
-from mdl.backtest.engine import run_backtest_signals
 
 OBJECTIVES = {
     "Sharpe": ("sharpe", False),

--- a/src/mdl/log_store.py
+++ b/src/mdl/log_store.py
@@ -85,7 +85,8 @@ def sanitize_meta(meta: dict) -> dict:
     return sanitized
 
 
-def _truncate_value(value):
+def _truncate_value(value: object) -> object:
+    """Truncate overly long string values before persistence."""
     if isinstance(value, str) and len(value) > 200:
         return f"{value[:20]}..."
     return value


### PR DESCRIPTION
### Motivation
- Ensure package metadata is more complete for tooling and packaging workflows. 
- Provide a stable, discoverable package version string when running the library in editable/local contexts. 
- Improve small typing and readability items to align with Python 3.10+ conventions. 

### Description
- Add `readme = "README.md"` to `pyproject.toml` to surface project README in package metadata. 
- Expose `mdl.__version__` in `src/mdl/__init__.py` by reading installed package metadata with a safe fallback for local execution, and export it via `__all__`. 
- Consolidate duplicate imports in `src/mdl/lab/strategy_lab.py` by importing `run_backtest_signals` alongside `BacktestParams` from the same module. 
- Modernize the TIMEFRAME mapping annotation in `src/mdl/data/ohlcv.py` to use `dict[str, int]` and remove an unnecessary `typing` import. 
- Add a brief docstring and explicit input/output type hints to `_truncate_value` in `src/mdl/log_store.py` for clarity without changing behavior. 

### Testing
- Ran `python -m compileall src/mdl` to validate syntax across the modified package and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a3d24c008328a89b6b362d44dfc2)