### PR TITLE
Add governance documentation and contribution guard rails

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# ARCHITECTURE
+
+## Purpose
+Market Decision Lab is a **research-only decision support** project. It does **not** execute live trades and does **not** provide financial advice.
+
+## Repository Layout
+- `app/` = Streamlit UI only (presentation and user interaction).
+- `src/mdl/` = reusable engine package (`mdl`) for decision logic, strategies, data, and backtesting.
+- `tools/` = CLI and development utilities.
+
+## Layering Rules
+- `app/` may import from `mdl.*`.
+- `mdl/` must not import `streamlit` or anything from `app/*`.
+- Do not use `sys.path` modifications or import hacks; use standard package imports only.
+
+## Public API Contract
+Treat the following as stable public surface:
+- `mdl.__version__`
+- `mdl.decision`, `mdl.scenarios`
+- `mdl.strategies` registry surface: `STRATEGIES`, `generate_candidates`
+
+## Extension Guidelines
+### Add a New Strategy
+1. Implement strategy logic in `src/mdl/strategies/` (new module or existing family module).
+2. Keep it reusable and UI-agnostic.
+3. Register it in `src/mdl/strategies/__init__.py` by adding a `StrategySpec` entry to `STRATEGIES`.
+4. Ensure candidate generation works through `generate_candidates`.
+
+### Add a New Data Source
+1. Add loader code under `src/mdl/data/`.
+2. Keep source-specific details in `mdl.data` and expose clean function interfaces.
+3. Keep `app/` clean: UI should call engine APIs, not own data-fetch business logic.
+
+### Backtest and Lab Modules
+- Keep `mdl.backtest` and `mdl.lab` reusable, deterministic where practical, and independent from Streamlit/UI concerns.
+- Prefer pure functions and explicit inputs/outputs so logic is testable outside the app.
+
+## Versioning (SemVer)
+- **MAJOR**: incompatible API or behavior changes in public `mdl` contracts.
+- **MINOR**: backward-compatible feature additions (new strategy, new optional API).
+- **PATCH**: backward-compatible fixes, docs, and internal improvements.
+
+When in doubt, bump conservatively and document user-visible implications.
+
+## Quality Bar
+- Repository code/docs/comments must remain English-only.
+- Keep changes minimal and focused; avoid broad refactors unless requested.
+- Do not add dependencies unless clearly justified.
+- Always run compile checks (at minimum `python -m compileall src/mdl`).

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -1,0 +1,41 @@
+# CODEX_GUIDE
+
+## Non-Negotiable Rules for Codex
+- Use English-only code, docs, comments, and commit/PR text.
+- Preserve existing behavior unless explicitly asked to change it.
+- Do not introduce `sys.path` hacks or non-standard imports.
+- Do not move files or refactor architecture unless explicitly requested.
+- `app/` is UI-only; new domain/business logic belongs in `src/mdl/`.
+- Avoid adding runtime dependencies unless explicitly justified and requested.
+
+## Guard Prompt (Paste at the Top of Every Codex Task)
+```text
+Guard rails for this task:
+- English-only changes.
+- No behavior/UI/business-logic changes unless explicitly requested.
+- No new runtime dependencies.
+- No sys.path hacks; use package imports.
+- Do not move files or refactor architecture unless asked.
+- app/ remains UI-only; new logic goes in src/mdl/.
+- Run: python -m compileall src/mdl
+```
+
+## Common Task Templates
+
+### Add a New Strategy
+- Add implementation under `src/mdl/strategies/`.
+- Register strategy in `src/mdl/strategies/__init__.py` (`STRATEGIES`, candidate compatibility).
+- Keep UI unchanged unless explicitly requested.
+- Constraints: no behavior changes outside scope, no new deps, run `python -m compileall src/mdl`.
+
+### Add a New Data Loader
+- Add loader under `src/mdl/data/` with clean function boundaries.
+- Wire usage through `mdl` package interfaces, not direct UI-side data logic.
+- Keep `app/` presentation-only.
+- Constraints: no unrelated behavior changes, no new deps, run `python -m compileall src/mdl`.
+
+### Small Refactor / Typing Cleanup
+- Keep refactor narrow and behavior-preserving.
+- Prefer clarity, typing improvements, and dead-code cleanup within current architecture.
+- Do not move modules unless asked.
+- Constraints: no behavior change, no new deps, run `python -m compileall src/mdl`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# CONTRIBUTING
+
+Thanks for contributing to Market Decision Lab.
+
+## Local setup
+```bash
+pip install -e .
+```
+
+## Run the app
+```bash
+streamlit run app/streamlit_app.py
+```
+
+## Smoke and compile checks
+```bash
+python -m compileall src/mdl
+python tools/smoke_check.py
+```
+
+If `tools/smoke_check.py` is unavailable in your branch, run at least the compile check.
+
+## Contribution rules
+- Respect layering: `app/` is UI-only; reusable logic belongs in `src/mdl/`.
+- Use English-only code, docs, comments, and PR text.
+- Do not add runtime dependencies unless clearly justified.
+- Do not introduce `sys.path` hacks; use package imports.
+- Keep PRs small, focused, and behavior-preserving unless a behavior change is explicitly requested.

--- a/PR_CHECKLIST.md
+++ b/PR_CHECKLIST.md
@@ -1,0 +1,9 @@
+# PR_CHECKLIST
+
+- [ ] Layering respected (`app/` UI vs `src/mdl/` engine).
+- [ ] No `sys.path` hacks introduced.
+- [ ] No new runtime dependencies.
+- [ ] English-only changes.
+- [ ] `python -m compileall src/mdl` passes.
+- [ ] Streamlit app starts (`streamlit run app/streamlit_app.py`).
+- [ ] Imports use the `mdl` package (standard package imports).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Market Decision Lab is a Streamlit decision-support application for evaluating w
 ## Requirements
 - Python 3.10+
 
+## Project Docs
+- [Architecture](ARCHITECTURE.md)
+- [Codex Guide](CODEX_GUIDE.md)
+- [Contributing](CONTRIBUTING.md)
+- [PR Checklist](PR_CHECKLIST.md)
+
 ## Run locally
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
### Motivation
- Provide clear governance and extension guidance so the repository can be safely extended over time without changing runtime behavior. 
- Enforce layering and import rules to keep `app/` UI-only and `src/mdl/` reusable and UI-agnostic. 
- Capture Codex-specific guard rails and common task templates to reduce accidental behavior changes or unsafe edits. 
- Offer a lightweight quality bar and pre-merge checklist to keep contributions small, English-only, and dependency-safe.

### Description
- Added `ARCHITECTURE.md` describing project purpose, repository layout, layering rules, public API contract (`mdl.__version__`, `mdl.decision`, `mdl.scenarios`, and strategies registry `STRATEGIES`, `generate_candidates`), extension guidelines, SemVer policy, and quality bar. 
- Added `CODEX_GUIDE.md` containing non-negotiable Codex rules, a reusable Guard Prompt block, and concise task templates for adding strategies, data loaders, and safe refactors. 
- Added `CONTRIBUTING.md` with local setup (`pip install -e .`), how to run the app (`streamlit run app/streamlit_app.py`), smoke/compile checks (`python -m compileall src/mdl`, `python tools/smoke_check.py`), and contribution rules. 
- Added `PR_CHECKLIST.md` with a concise review checklist and updated `README.md` to include a new “Project Docs” section that links to the new files using relative paths. 
- No runtime code, business logic, UI behavior, or dependencies were changed or added.

### Testing
- Ran `python -m compileall src/mdl` and confirmed the compile check completed successfully. 
- No other automated tests were added or modified as part of these documentation and governance changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a71dea84832891cf1f81f83a369e)