### PR TITLE
Streamlit Cloud packaging fix: replace editable install, add smoke tests & README deploy notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ pip install -r requirements.txt
 streamlit run app/streamlit_app.py
 ```
 
+### Environment variables
+- `MDL_LOG_DIR` (optional): directory for CSV logs. Default is `app/data/logs`.
+
+No API keys are required for the default public market data flow. If you add private integrations, keep secrets in environment variables or Streamlit Cloud secrets and never commit them.
+
 ## Strategy Lab (Auto)
 The Strategy Lab searches through a compact library of simple long-only strategies and parameter combinations, then ranks candidates by your selected objective:
 - **Sharpe**
@@ -132,5 +137,7 @@ The audit will fail if any known vulnerabilities are found, ensuring that securi
 ## Streamlit Cloud deployment
 1. Push this repository to GitHub.
 2. Create a new Streamlit Cloud app from this repository.
-3. Set the main file path to `app/streamlit_app.py`.
-4. Deploy.
+3. Ensure dependencies install from `requirements.txt` (includes local package install via `.`).
+4. Set the main file path to `app/streamlit_app.py`.
+5. (Optional) configure `MDL_LOG_DIR` in app secrets or environment variables.
+6. Deploy.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ streamlit==1.37.0
 pandas==2.2.2
 numpy==1.26.4
 ccxt==4.3.97
-
--e .
+.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from mdl import evaluate_run, final_decision
+
+
+def test_evaluate_run_returns_expected_shape() -> None:
+    metrics = {
+        "Annualized Return %": 20.0,
+        "Max Drawdown %": 10.0,
+        "Number of Trades": 25,
+        "Trades Per Week": 2.0,
+        "Expectancy %": 0.8,
+    }
+    decision = evaluate_run(metrics)
+    assert set(["status", "color", "reasons", "recommendation", "score"]).issubset(decision)
+
+
+def test_final_decision_prefers_green_scenario() -> None:
+    scenarios = {
+        "A": {"metrics": {"Annualized Return %": 10.0, "Max Drawdown %": 20.0}, "decision": {"status": "YELLOW", "score": 1.0}},
+        "B": {"metrics": {"Annualized Return %": 25.0, "Max Drawdown %": 10.0}, "decision": {"status": "GREEN", "score": 2.0}},
+        "C": {"metrics": {"Annualized Return %": 5.0, "Max Drawdown %": 25.0}, "decision": {"status": "RED", "score": -1.0}},
+    }
+
+    decision = final_decision(scenarios)
+
+    assert decision["label"] == "INVEST"
+    assert decision["recommended"] == "B"


### PR DESCRIPTION
### Motivation
- Streamlit Cloud can fail to install projects that use an editable `-e .` entry in `requirements.txt`, so the local package install needs to be deploy-friendly.
- There were no lightweight automated checks ensuring the `mdl` public API imports correctly in CI-like environments, so add minimal smoke coverage to prevent regressions.
- Deployment docs lacked explicit env var guidance and Streamlit Cloud install/run notes, which makes on-boarding and deployment brittle.

### Description
- Replaced the editable install entry in `requirements.txt` (`-e .`) with a standard local install `.` to improve Streamlit Cloud compatibility and avoid build-isolation issues.
- Added a minimal test file `tests/test_smoke.py` that imports public `mdl` helpers (`evaluate_run`, `final_decision`) and verifies expected shapes and preference behavior without network calls.
- Updated `README.md` with a short "Environment variables" section and expanded Streamlit Cloud deployment steps to document `MDL_LOG_DIR` and the main file path.
- Audited `app/streamlit_app.py` for missing helper calls and confirmed `save_single_run`, `append_event`, and `append_error` are defined and use existing `src/mdl/storage.py` and `src/mdl/log_store.py` APIs; no functional changes to app UI or business logic were made.

### Testing
- Ran `python -m compileall .` and it completed successfully.
- Attempted `python -m pip install -r requirements.txt` in this environment and the dependency build step failed due to network/proxy access when fetching build tooling (environment issue), not project code.
- Installed the package locally with `python -m pip install -e . --no-build-isolation` and `python -c "import mdl; print('mdl ok')"` succeeded, printing `mdl ok`.
- Ran unit tests with `pytest` and the new smoke tests passed: `2 passed`.
- Performed a minimal Streamlit startup check (`streamlit run app/streamlit_app.py`) and the app printed the startup banner (local server URLs) indicating the app starts; the process was stopped after verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987aa8b5cbc832894d9994fa2db28f6)