### PR TITLE
Lazy-load ccxt in OHLCV fetch to prevent Streamlit startup blocking

### DIFF
--- a/src/mdl/data/ohlcv.py
+++ b/src/mdl/data/ohlcv.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import math
 import random
 import time
-import ccxt
 import pandas as pd
 
 TIMEFRAME_TO_MINUTES: dict[str, int] = {"1m": 1, "5m": 5, "15m": 15, "1h": 60, "4h": 240, "1d": 1440}
@@ -36,6 +35,8 @@ def select_symbol(exchange_name: str, asset: str, markets: dict) -> str:
 
 def fetch_ohlcv(exchange_name: str, symbol: str, timeframe: str, days: int) -> pd.DataFrame:
     """Fetch OHLCV candles for a symbol and timeframe covering `days`."""
+    import ccxt  # Lazy import avoids blocking Streamlit Cloud startup during module import.
+
     if timeframe not in TIMEFRAME_TO_MINUTES:
         raise ValueError(f"Unsupported timeframe: {timeframe}")
 


### PR DESCRIPTION
### Motivation

- Avoid Streamlit Cloud indefinite startup spinner by deferring the heavy/top-level `ccxt` import until runtime inside the function that uses it.

### Description

- Moved `import ccxt` from module scope into `fetch_ohlcv()` in `src/mdl/data/ohlcv.py` and added a short inline comment explaining this lazy import, with no changes to existing OHLCV fetching or retry logic.

### Testing

- Ran `python -m compileall .` (success); `python -c "import mdl; print('mdl ok')"` failed in this container because the package is not installed; `python -m pip install -r requirements.txt` failed due to proxy/build-dependency issues in this environment; `streamlit run app/streamlit_app.py --server.headless true --server.port 8501` started the server and `curl http://127.0.0.1:8501` returned the Streamlit HTML shell confirming the initial UI render, and I verified `requirements.txt` has no `-e .` editable install and the Streamlit entrypoint is `app/streamlit_app.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b2aa19048328995aaf274448ae29)