### PR TITLE
Improve Streamlit Cloud startup reliability and diagnostics

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -31,6 +31,8 @@ COMPARE_MAX_DAYS = 41
 LAB_MAX_RUNS = 200
 
 st.set_page_config(page_title="Market Decision Lab", layout="wide")
+print("Startup OK")
+st.caption("Startup OK")
 st.title("Market Decision Lab")
 st.caption("Research-only decision support. No live trading. No financial advice.")
 
@@ -281,189 +283,123 @@ def run_compare_check(inputs: dict, run_id: str):
     }
 
 
-if "quick_result" not in st.session_state:
-    st.session_state.quick_result = None
-if "compare_result" not in st.session_state:
-    st.session_state.compare_result = None
-if "strategy_lab_result" not in st.session_state:
-    st.session_state.strategy_lab_result = None
+def run_app() -> None:
+    if "quick_result" not in st.session_state:
+        st.session_state.quick_result = None
+    if "compare_result" not in st.session_state:
+        st.session_state.compare_result = None
+    if "strategy_lab_result" not in st.session_state:
+        st.session_state.strategy_lab_result = None
 
-with st.sidebar:
-    st.header("Controls")
-    mode = st.selectbox("Mode", ["Quick Check", "A/B/C Compare", "Strategy Lab (Auto)"], index=0)
-    with st.form("controls_form"):
-        st.subheader("Quick / Compare")
-        exchange = st.selectbox("Exchange", ["kraken", "coinbase"], index=0)
-        asset = st.selectbox("Asset", ASSETS, index=0)
-        timeframe = st.selectbox("Timeframe", ["1h", "4h", "1d"], index=1)
-        quick_days_max = TIMEFRAME_DAY_LIMITS.get(timeframe, 365)
-        days = st.number_input("Days", min_value=7, max_value=quick_days_max, value=min(30, quick_days_max), step=1)
-        st.caption(f"Quick Check day limit for {timeframe}: {quick_days_max} (exchange API limit is 1000 candles).")
-        st.caption(f"Compare mode is capped at {COMPARE_MAX_DAYS} days because it includes 1h candles (1000-candle API limit).")
+    with st.sidebar:
+        st.header("Controls")
+        mode = st.selectbox("Mode", ["Quick Check", "A/B/C Compare", "Strategy Lab (Auto)"], index=0)
+        with st.form("controls_form"):
+            st.subheader("Quick / Compare")
+            exchange = st.selectbox("Exchange", ["kraken", "coinbase"], index=0)
+            asset = st.selectbox("Asset", ASSETS, index=0)
+            timeframe = st.selectbox("Timeframe", ["1h", "4h", "1d"], index=1)
+            quick_days_max = TIMEFRAME_DAY_LIMITS.get(timeframe, 365)
+            days = st.number_input("Days", min_value=7, max_value=quick_days_max, value=min(30, quick_days_max), step=1)
+            st.caption(f"Quick Check day limit for {timeframe}: {quick_days_max} (exchange API limit is 1000 candles).")
+            st.caption(f"Compare mode is capped at {COMPARE_MAX_DAYS} days because it includes 1h candles (1000-candle API limit).")
 
-        with st.expander("Advanced", expanded=False):
-            ema_window = st.selectbox("EMA window", [20, 50], index=0)
-            signal_mode = st.selectbox("Signal mode", ["strict", "relaxed"], index=0)
-            entry_mode = st.selectbox("Entry mode", ["next_open", "signal_close"], index=0)
-            sl_mult = st.number_input("SL ATR multiple", min_value=0.5, max_value=5.0, value=1.5, step=0.1)
-            tp_mult = st.number_input("TP ATR multiple", min_value=0.5, max_value=10.0, value=2.5, step=0.1)
-            fee = st.number_input("Fee per side", min_value=0.0, max_value=0.01, value=0.0006, step=0.0001, format="%.4f")
-            slippage = st.number_input(
-                "Slippage per side",
-                min_value=0.0,
-                max_value=0.01,
-                value=0.0002,
-                step=0.0001,
-                format="%.4f",
+            with st.expander("Advanced", expanded=False):
+                ema_window = st.selectbox("EMA window", [20, 50], index=0)
+                signal_mode = st.selectbox("Signal mode", ["strict", "relaxed"], index=0)
+                entry_mode = st.selectbox("Entry mode", ["next_open", "signal_close"], index=0)
+                sl_mult = st.number_input("SL ATR multiple", min_value=0.5, max_value=5.0, value=1.5, step=0.1)
+                tp_mult = st.number_input("TP ATR multiple", min_value=0.5, max_value=10.0, value=2.5, step=0.1)
+                fee = st.number_input("Fee per side", min_value=0.0, max_value=0.01, value=0.0006, step=0.0001, format="%.4f")
+                slippage = st.number_input(
+                    "Slippage per side",
+                    min_value=0.0,
+                    max_value=0.01,
+                    value=0.0002,
+                    step=0.0001,
+                    format="%.4f",
+                )
+
+            submitted_quick = st.form_submit_button("Run Quick Check", use_container_width=True, disabled=mode != "Quick Check")
+            submitted_compare = st.form_submit_button("Run A/B/C Compare", use_container_width=True, disabled=mode != "A/B/C Compare")
+
+        st.divider()
+        st.subheader("Strategy Lab (Auto)")
+        objective = st.selectbox("Objective", list(OBJECTIVES.keys()), index=0)
+        max_runs = st.slider("Max strategy runs", min_value=10, max_value=LAB_MAX_RUNS, value=60, step=10)
+        top_n = st.slider("Top strategies to display", min_value=3, max_value=20, value=10, step=1)
+        submitted_lab = st.button("Run Strategy Lab", use_container_width=True, disabled=mode != "Strategy Lab (Auto)")
+
+        st.divider()
+        st.subheader("Export")
+        if st.button("Export runs.csv", use_container_width=True):
+            export_df, export_warning = load_runs_for_export(ROOT / "data" / "app.db")
+            if export_warning:
+                st.warning(export_warning)
+                st.session_state.pop("runs_csv_export", None)
+            elif export_df.empty:
+                st.warning("No runs available to export.")
+                st.session_state.pop("runs_csv_export", None)
+            else:
+                st.session_state.runs_csv_export = export_df.to_csv(index=False).encode("utf-8")
+
+        if "runs_csv_export" in st.session_state:
+            st.download_button(
+                "Download runs.csv",
+                data=st.session_state.runs_csv_export,
+                file_name="runs.csv",
+                mime="text/csv",
+                use_container_width=True,
             )
 
-        submitted_quick = st.form_submit_button("Run Quick Check", use_container_width=True, disabled=mode != "Quick Check")
-        submitted_compare = st.form_submit_button("Run A/B/C Compare", use_container_width=True, disabled=mode != "A/B/C Compare")
+    inputs = {
+        "exchange": exchange,
+        "asset": asset,
+        "timeframe": timeframe,
+        "days": int(days),
+        "ema_window": ema_window,
+        "signal_mode": signal_mode,
+        "entry_mode": entry_mode,
+        "sl_mult": float(sl_mult),
+        "tp_mult": float(tp_mult),
+        "fee": float(fee),
+        "slippage": float(slippage),
+    }
 
-    st.divider()
-    st.subheader("Strategy Lab (Auto)")
-    objective = st.selectbox("Objective", list(OBJECTIVES.keys()), index=0)
-    max_runs = st.slider("Max strategy runs", min_value=10, max_value=LAB_MAX_RUNS, value=60, step=10)
-    top_n = st.slider("Top strategies to display", min_value=3, max_value=20, value=10, step=1)
-    submitted_lab = st.button("Run Strategy Lab", use_container_width=True, disabled=mode != "Strategy Lab (Auto)")
+    lab_inputs = {
+        "exchange": exchange,
+        "asset": asset,
+        "timeframe": timeframe,
+        "days": int(days),
+        "objective": objective,
+        "max_runs": int(max_runs),
+        "top_n": int(top_n),
+    }
 
-    st.divider()
-    st.subheader("Export")
-    if st.button("Export runs.csv", use_container_width=True):
-        export_df, export_warning = load_runs_for_export(ROOT / "data" / "app.db")
-        if export_warning:
-            st.warning(export_warning)
-            st.session_state.pop("runs_csv_export", None)
-        elif export_df.empty:
-            st.warning("No runs available to export.")
-            st.session_state.pop("runs_csv_export", None)
-        else:
-            st.session_state.runs_csv_export = export_df.to_csv(index=False).encode("utf-8")
-
-    if "runs_csv_export" in st.session_state:
-        st.download_button(
-            "Download runs.csv",
-            data=st.session_state.runs_csv_export,
-            file_name="runs.csv",
-            mime="text/csv",
-            use_container_width=True,
-        )
-
-inputs = {
-    "exchange": exchange,
-    "asset": asset,
-    "timeframe": timeframe,
-    "days": int(days),
-    "ema_window": ema_window,
-    "signal_mode": signal_mode,
-    "entry_mode": entry_mode,
-    "sl_mult": float(sl_mult),
-    "tp_mult": float(tp_mult),
-    "fee": float(fee),
-    "slippage": float(slippage),
-}
-
-lab_inputs = {
-    "exchange": exchange,
-    "asset": asset,
-    "timeframe": timeframe,
-    "days": int(days),
-    "objective": objective,
-    "max_runs": int(max_runs),
-    "top_n": int(top_n),
-}
-
-if submitted_quick:
-    run_id = str(uuid.uuid4())
-    run_started = time.perf_counter()
-    rate_limit_hits = 0
-    append_event(run_id, "INFO", "ui.submit", "User submitted quick check", meta=inputs)
-    try:
-        with st.spinner("Computing..."):
-            st.session_state.quick_result = run_quick_check(inputs, run_id)
-        latency_ms = int((time.perf_counter() - run_started) * 1000)
-        quick_result = st.session_state.quick_result
-        LOG_STORE.append_run(
-            {
-                "run_id": run_id,
-                "run_ts": utc_now_iso(),
-                "exchange": inputs["exchange"],
-                "symbol": quick_result["symbol"],
-                "timeframe": inputs["timeframe"],
-                "days": int(inputs["days"]),
-                "status": decision_to_status(quick_result["decision"]),
-                "latency_ms": latency_ms,
-                "rate_limit_hits": rate_limit_hits,
-                "params_json": to_json_str(sanitize_meta(inputs)),
-                "metrics_json": to_json_str(quick_result["metrics"]),
-                "decision_json": to_json_str(quick_result["decision"]),
-            }
-        )
-    except Exception as exc:
-        if "Too many requests" in str(exc) or "DDoSProtection" in str(exc):
-            rate_limit_hits += 1
-        append_error(
-            run_id,
-            exc,
-            {
-                "stage": "data.fetch_ohlcv",
-                "exchange": inputs["exchange"],
-                "symbol": inputs["asset"],
-                "timeframe": inputs["timeframe"],
-                "days": int(inputs["days"]),
-            },
-        )
-        latency_ms = int((time.perf_counter() - run_started) * 1000)
-        LOG_STORE.append_run(
-            {
-                "run_id": run_id,
-                "run_ts": utc_now_iso(),
-                "exchange": inputs["exchange"],
-                "symbol": inputs["asset"],
-                "timeframe": inputs["timeframe"],
-                "days": int(inputs["days"]),
-                "status": "fail",
-                "latency_ms": latency_ms,
-                "rate_limit_hits": rate_limit_hits,
-                "params_json": to_json_str(sanitize_meta(inputs)),
-                "metrics_json": to_json_str({}),
-                "decision_json": to_json_str({}),
-            }
-        )
-        render_error("Quick check failed. Please verify inputs and try again.", exc)
-
-if submitted_compare:
-    if int(inputs["days"]) > COMPARE_MAX_DAYS:
-        st.warning(f"Compare supports up to {COMPARE_MAX_DAYS} days to stay within exchange candle limits.")
-    else:
+    if submitted_quick:
         run_id = str(uuid.uuid4())
         run_started = time.perf_counter()
         rate_limit_hits = 0
-        append_event(run_id, "INFO", "ui.submit", "User submitted scenario compare", meta=inputs)
+        append_event(run_id, "INFO", "ui.submit", "User submitted quick check", meta=inputs)
         try:
             with st.spinner("Computing..."):
-                st.session_state.compare_result = run_compare_check(inputs, run_id)
-
+                st.session_state.quick_result = run_quick_check(inputs, run_id)
             latency_ms = int((time.perf_counter() - run_started) * 1000)
-            compare_result = st.session_state.compare_result
-            final_decision_payload = compare_result["final"]
-            final_status = "ok" if final_decision_payload.get("label") == "INVEST" else "warn"
-            if final_decision_payload.get("label") == "NO":
-                final_status = "fail"
+            quick_result = st.session_state.quick_result
             LOG_STORE.append_run(
                 {
                     "run_id": run_id,
                     "run_ts": utc_now_iso(),
                     "exchange": inputs["exchange"],
-                    "symbol": compare_result["symbol"],
+                    "symbol": quick_result["symbol"],
                     "timeframe": inputs["timeframe"],
                     "days": int(inputs["days"]),
-                    "status": final_status,
+                    "status": decision_to_status(quick_result["decision"]),
                     "latency_ms": latency_ms,
                     "rate_limit_hits": rate_limit_hits,
                     "params_json": to_json_str(sanitize_meta(inputs)),
-                    "metrics_json": to_json_str({key: value["metrics"] for key, value in compare_result["scenarios"].items()}),
-                    "decision_json": to_json_str(final_decision_payload),
+                    "metrics_json": to_json_str(quick_result["metrics"]),
+                    "decision_json": to_json_str(quick_result["decision"]),
                 }
             )
         except Exception as exc:
@@ -497,142 +433,217 @@ if submitted_compare:
                     "decision_json": to_json_str({}),
                 }
             )
-            render_error("Scenario compare failed. Please verify inputs and try again.", exc)
+            render_error("Quick check failed. Please verify inputs and try again.", exc)
 
-if submitted_lab:
-    run_id = str(uuid.uuid4())
-    append_event(run_id, "INFO", "ui.submit", "User submitted strategy lab", meta=lab_inputs)
-    try:
-        with st.spinner("Running auto strategy search..."):
-            markets = _cached_markets(lab_inputs["exchange"])
-            symbol = select_symbol(lab_inputs["exchange"], lab_inputs["asset"], markets)
-            results_df, details = _cached_strategy_lab(
-                lab_inputs["exchange"],
-                symbol,
-                lab_inputs["timeframe"],
-                int(lab_inputs["days"]),
-                lab_inputs["objective"],
-                int(lab_inputs["max_runs"]),
-                int(lab_inputs["top_n"]),
-            )
-            st.session_state.strategy_lab_result = {
-                "symbol": symbol,
-                "results_df": results_df,
-                "details": details,
-                "inputs": lab_inputs,
-            }
-    except Exception as exc:
-        append_error(run_id, exc, {"stage": "strategy_lab", **lab_inputs})
-        render_error("Strategy Lab failed. Please verify inputs and try again.", exc)
+    if submitted_compare:
+        if int(inputs["days"]) > COMPARE_MAX_DAYS:
+            st.warning(f"Compare supports up to {COMPARE_MAX_DAYS} days to stay within exchange candle limits.")
+        else:
+            run_id = str(uuid.uuid4())
+            run_started = time.perf_counter()
+            rate_limit_hits = 0
+            append_event(run_id, "INFO", "ui.submit", "User submitted scenario compare", meta=inputs)
+            try:
+                with st.spinner("Computing..."):
+                    st.session_state.compare_result = run_compare_check(inputs, run_id)
 
-quick_tab, compare_tab, strategy_tab, history_tab = st.tabs(["Quick", "Compare", "Strategy Lab", "History"])
-
-with quick_tab:
-    quick_result = st.session_state.quick_result
-    if quick_result is None:
-        st.info("Configure inputs in the sidebar and press **Run Quick Check**.")
-    else:
-        decision = quick_result["decision"]
-        metrics = quick_result["metrics"]
-        with st.container(border=True):
-            st.subheader("Decision Summary")
-            st.markdown(f"### {decision['color']} {decision['recommendation']}")
-            st.write("; ".join(decision["reasons"]))
-
-        m1, m2, m3, m4 = st.columns(4)
-        m1.metric("Annualized Return", fmt_pct(metrics["Annualized Return %"]))
-        m2.metric("Max Drawdown", fmt_pct(metrics["Max Drawdown %"]))
-        m3.metric("Trades", f"{metrics['Number of Trades']}")
-        m4.metric("Expectancy", fmt_pct(metrics["Expectancy %"]))
-
-        st.line_chart(quick_result["backtest_df"].set_index("ts")["equity"])
-        st.dataframe(quick_result["trades_df"], use_container_width=True)
-
-with compare_tab:
-    compare_result = st.session_state.compare_result
-    if compare_result is None:
-        st.info("Configure inputs in the sidebar and press **Run A/B/C Compare**.")
-    else:
-        final = compare_result["final"]
-        scenarios = compare_result["scenarios"]
-
-        with st.container(border=True):
-            st.subheader("Decision Summary")
-            st.markdown(f"### {final['label']}")
-            st.write(f"Recommended scenario: **{final['recommended']}**")
-            st.write(final["text"])
-
-        cards = st.columns(3)
-        for idx, key in enumerate(["A", "B", "C"]):
-            sc = scenarios[key]
-            d = sc["decision"]
-            with cards[idx]:
-                with st.container(border=True):
-                    st.markdown(f"#### Scenario {key}: {d['color']} {d['status']}")
-                    st.write(f"Annualized Return: {fmt_pct(sc['metrics']['Annualized Return %'])}")
-                    st.write(f"Max Drawdown: {fmt_pct(sc['metrics']['Max Drawdown %'])}")
-                    st.write(f"Trades/Week: {sc['metrics']['Trades Per Week']:.2f}")
-                    st.caption(d["recommendation"])
-
-        chosen = st.selectbox("Inspect scenario", ["A", "B", "C"], index=0, key="compare_inspect_scenario")
-        inspect = scenarios[chosen]
-        st.line_chart(inspect["backtest_df"].set_index("ts")["equity"])
-        st.dataframe(inspect["trades_df"], use_container_width=True)
-
-with strategy_tab:
-    st.caption("Research-only decision support. No live trading. No financial advice.")
-    strategy_lab_result = st.session_state.strategy_lab_result
-    if strategy_lab_result is None:
-        st.info("Set Strategy Lab inputs in the sidebar and click **Run Strategy Lab**.")
-    else:
-        results_df = strategy_lab_result["results_df"]
-        details = strategy_lab_result["details"]
-        top_df = results_df.copy()
-
-        st.subheader("Top Strategy Candidates")
-        st.dataframe(
-            top_df[["candidate_id", "strategy_name", "total_return_pct", "max_drawdown_pct", "sharpe", "win_rate", "n_trades", "params"]],
-            use_container_width=True,
-        )
-
-        candidate_options = top_df["candidate_id"].tolist()
-        selected_candidate = st.selectbox("Select strategy", candidate_options, key="strategy_lab_select")
-        selected = details[selected_candidate]
-
-        st.markdown("### Strategy Explanation")
-        st.write(selected["description"])
-
-        c1, c2, c3, c4 = st.columns(4)
-        c1.metric("Return", fmt_pct(selected["metrics"]["total_return_pct"]))
-        c2.metric("Max Drawdown", fmt_pct(selected["metrics"]["max_drawdown_pct"]))
-        c3.metric("Sharpe", f"{selected['metrics']['sharpe']:.2f}")
-        c4.metric("Win Rate", fmt_pct(selected["metrics"]["win_rate"]))
-
-        st.line_chart(selected["backtest_df"].set_index("ts")["equity"])
-        st.dataframe(selected["trades_df"], use_container_width=True)
-
-with history_tab:
-    st.subheader("History")
-    runs = load_runs(limit=50)
-    if runs.empty:
-        st.info("No runs stored yet.")
-    else:
-        view_runs = runs[["run_ts", "exchange", "symbol", "timeframe", "days", "run_id"]].copy()
-        st.dataframe(view_runs, use_container_width=True)
-        run_id = st.selectbox("Load trades for run", view_runs["run_id"].tolist(), key="history_run_id")
-        if run_id:
-            trades = load_trades(run_id)
-            st.dataframe(trades, use_container_width=True)
-            # Check if run_id exists in dataframe before accessing
-            matching_runs = runs.loc[runs["run_id"] == run_id]
-            if not matching_runs.empty:
-                selected = matching_runs.iloc[0]
-                st.json(
+                latency_ms = int((time.perf_counter() - run_started) * 1000)
+                compare_result = st.session_state.compare_result
+                final_decision_payload = compare_result["final"]
+                final_status = "ok" if final_decision_payload.get("label") == "INVEST" else "warn"
+                if final_decision_payload.get("label") == "NO":
+                    final_status = "fail"
+                LOG_STORE.append_run(
                     {
-                        "params": json.loads(selected["params_json"]),
-                        "metrics": json.loads(selected["metrics_json"]),
-                        "decision": json.loads(selected["decision_json"]),
+                        "run_id": run_id,
+                        "run_ts": utc_now_iso(),
+                        "exchange": inputs["exchange"],
+                        "symbol": compare_result["symbol"],
+                        "timeframe": inputs["timeframe"],
+                        "days": int(inputs["days"]),
+                        "status": final_status,
+                        "latency_ms": latency_ms,
+                        "rate_limit_hits": rate_limit_hits,
+                        "params_json": to_json_str(sanitize_meta(inputs)),
+                        "metrics_json": to_json_str({key: value["metrics"] for key, value in compare_result["scenarios"].items()}),
+                        "decision_json": to_json_str(final_decision_payload),
                     }
                 )
-            else:
-                st.warning(f"Run {run_id} not found in loaded history.")
+            except Exception as exc:
+                if "Too many requests" in str(exc) or "DDoSProtection" in str(exc):
+                    rate_limit_hits += 1
+                append_error(
+                    run_id,
+                    exc,
+                    {
+                        "stage": "data.fetch_ohlcv",
+                        "exchange": inputs["exchange"],
+                        "symbol": inputs["asset"],
+                        "timeframe": inputs["timeframe"],
+                        "days": int(inputs["days"]),
+                    },
+                )
+                latency_ms = int((time.perf_counter() - run_started) * 1000)
+                LOG_STORE.append_run(
+                    {
+                        "run_id": run_id,
+                        "run_ts": utc_now_iso(),
+                        "exchange": inputs["exchange"],
+                        "symbol": inputs["asset"],
+                        "timeframe": inputs["timeframe"],
+                        "days": int(inputs["days"]),
+                        "status": "fail",
+                        "latency_ms": latency_ms,
+                        "rate_limit_hits": rate_limit_hits,
+                        "params_json": to_json_str(sanitize_meta(inputs)),
+                        "metrics_json": to_json_str({}),
+                        "decision_json": to_json_str({}),
+                    }
+                )
+                render_error("Scenario compare failed. Please verify inputs and try again.", exc)
+
+    if submitted_lab:
+        run_id = str(uuid.uuid4())
+        append_event(run_id, "INFO", "ui.submit", "User submitted strategy lab", meta=lab_inputs)
+        try:
+            with st.spinner("Running auto strategy search..."):
+                markets = _cached_markets(lab_inputs["exchange"])
+                symbol = select_symbol(lab_inputs["exchange"], lab_inputs["asset"], markets)
+                results_df, details = _cached_strategy_lab(
+                    lab_inputs["exchange"],
+                    symbol,
+                    lab_inputs["timeframe"],
+                    int(lab_inputs["days"]),
+                    lab_inputs["objective"],
+                    int(lab_inputs["max_runs"]),
+                    int(lab_inputs["top_n"]),
+                )
+                st.session_state.strategy_lab_result = {
+                    "symbol": symbol,
+                    "results_df": results_df,
+                    "details": details,
+                    "inputs": lab_inputs,
+                }
+        except Exception as exc:
+            append_error(run_id, exc, {"stage": "strategy_lab", **lab_inputs})
+            render_error("Strategy Lab failed. Please verify inputs and try again.", exc)
+
+    quick_tab, compare_tab, strategy_tab, history_tab = st.tabs(["Quick", "Compare", "Strategy Lab", "History"])
+
+    with quick_tab:
+        quick_result = st.session_state.quick_result
+        if quick_result is None:
+            st.info("Configure inputs in the sidebar and press **Run Quick Check**.")
+        else:
+            decision = quick_result["decision"]
+            metrics = quick_result["metrics"]
+            with st.container(border=True):
+                st.subheader("Decision Summary")
+                st.markdown(f"### {decision['color']} {decision['recommendation']}")
+                st.write("; ".join(decision["reasons"]))
+
+            m1, m2, m3, m4 = st.columns(4)
+            m1.metric("Annualized Return", fmt_pct(metrics["Annualized Return %"]))
+            m2.metric("Max Drawdown", fmt_pct(metrics["Max Drawdown %"]))
+            m3.metric("Trades", f"{metrics['Number of Trades']}")
+            m4.metric("Expectancy", fmt_pct(metrics["Expectancy %"]))
+
+            st.line_chart(quick_result["backtest_df"].set_index("ts")["equity"])
+            st.dataframe(quick_result["trades_df"], use_container_width=True)
+
+    with compare_tab:
+        compare_result = st.session_state.compare_result
+        if compare_result is None:
+            st.info("Configure inputs in the sidebar and press **Run A/B/C Compare**.")
+        else:
+            final = compare_result["final"]
+            scenarios = compare_result["scenarios"]
+
+            with st.container(border=True):
+                st.subheader("Decision Summary")
+                st.markdown(f"### {final['label']}")
+                st.write(f"Recommended scenario: **{final['recommended']}**")
+                st.write(final["text"])
+
+            cards = st.columns(3)
+            for idx, key in enumerate(["A", "B", "C"]):
+                sc = scenarios[key]
+                d = sc["decision"]
+                with cards[idx]:
+                    with st.container(border=True):
+                        st.markdown(f"#### Scenario {key}: {d['color']} {d['status']}")
+                        st.write(f"Annualized Return: {fmt_pct(sc['metrics']['Annualized Return %'])}")
+                        st.write(f"Max Drawdown: {fmt_pct(sc['metrics']['Max Drawdown %'])}")
+                        st.write(f"Trades/Week: {sc['metrics']['Trades Per Week']:.2f}")
+                        st.caption(d["recommendation"])
+
+            chosen = st.selectbox("Inspect scenario", ["A", "B", "C"], index=0, key="compare_inspect_scenario")
+            inspect = scenarios[chosen]
+            st.line_chart(inspect["backtest_df"].set_index("ts")["equity"])
+            st.dataframe(inspect["trades_df"], use_container_width=True)
+
+    with strategy_tab:
+        st.caption("Research-only decision support. No live trading. No financial advice.")
+        strategy_lab_result = st.session_state.strategy_lab_result
+        if strategy_lab_result is None:
+            st.info("Set Strategy Lab inputs in the sidebar and click **Run Strategy Lab**.")
+        else:
+            results_df = strategy_lab_result["results_df"]
+            details = strategy_lab_result["details"]
+            top_df = results_df.copy()
+
+            st.subheader("Top Strategy Candidates")
+            st.dataframe(
+                top_df[["candidate_id", "strategy_name", "total_return_pct", "max_drawdown_pct", "sharpe", "win_rate", "n_trades", "params"]],
+                use_container_width=True,
+            )
+
+            candidate_options = top_df["candidate_id"].tolist()
+            selected_candidate = st.selectbox("Select strategy", candidate_options, key="strategy_lab_select")
+            selected = details[selected_candidate]
+
+            st.markdown("### Strategy Explanation")
+            st.write(selected["description"])
+
+            c1, c2, c3, c4 = st.columns(4)
+            c1.metric("Return", fmt_pct(selected["metrics"]["total_return_pct"]))
+            c2.metric("Max Drawdown", fmt_pct(selected["metrics"]["max_drawdown_pct"]))
+            c3.metric("Sharpe", f"{selected['metrics']['sharpe']:.2f}")
+            c4.metric("Win Rate", fmt_pct(selected["metrics"]["win_rate"]))
+
+            st.line_chart(selected["backtest_df"].set_index("ts")["equity"])
+            st.dataframe(selected["trades_df"], use_container_width=True)
+
+    with history_tab:
+        st.subheader("History")
+        runs = load_runs(limit=50)
+        if runs.empty:
+            st.info("No runs stored yet.")
+        else:
+            view_runs = runs[["run_ts", "exchange", "symbol", "timeframe", "days", "run_id"]].copy()
+            st.dataframe(view_runs, use_container_width=True)
+            run_id = st.selectbox("Load trades for run", view_runs["run_id"].tolist(), key="history_run_id")
+            if run_id:
+                trades = load_trades(run_id)
+                st.dataframe(trades, use_container_width=True)
+                # Check if run_id exists in dataframe before accessing
+                matching_runs = runs.loc[runs["run_id"] == run_id]
+                if not matching_runs.empty:
+                    selected = matching_runs.iloc[0]
+                    st.json(
+                        {
+                            "params": json.loads(selected["params_json"]),
+                            "metrics": json.loads(selected["metrics_json"]),
+                            "decision": json.loads(selected["decision_json"]),
+                        }
+                    )
+                else:
+                    st.warning(f"Run {run_id} not found in loaded history.")
+
+
+try:
+    run_app()
+except Exception as exc:
+    print("Startup failure in app construction:", exc)
+    traceback.print_exc()
+    raise

--- a/src/mdl/data/ohlcv.py
+++ b/src/mdl/data/ohlcv.py
@@ -35,7 +35,7 @@ def select_symbol(exchange_name: str, asset: str, markets: dict) -> str:
 
 def fetch_ohlcv(exchange_name: str, symbol: str, timeframe: str, days: int) -> pd.DataFrame:
     """Fetch OHLCV candles for a symbol and timeframe covering `days`."""
-    import ccxt  # Lazy import avoids blocking Streamlit Cloud startup during module import.
+    import ccxt  # Lazy import to avoid blocking Streamlit startup.
 
     if timeframe not in TIMEFRAME_TO_MINUTES:
         raise ValueError(f"Unsupported timeframe: {timeframe}")


### PR DESCRIPTION
### Motivation
- The app was stuck during startup due to opaque top-level failures and import-time blockers that keep Streamlit in a restart loop.
- Hidden import-time network/IO (notably `ccxt`) and unlogged exceptions prevent actionable Cloud logs. 
- Diagnostics must be visible in stdout and the app must avoid calling Streamlit APIs before `set_page_config` or doing blocking imports at module import time.

### Description
- Added a non-invasive startup marker directly after `st.set_page_config`: `print("Startup OK")` and `st.caption("Startup OK")` so logs and UI show the app reached initial startup. 
- Moved top-level UI construction into `run_app()` and wrapped the `run_app()` invocation in a `try/except` that prints the exception and full traceback to stdout before re-raising so Streamlit Cloud logs reveal the real crash reason. 
- Ensured `ccxt` remains a lazy import inside `fetch_ohlcv()` and updated the inline comment to explicitly state the lazy-import rationale to avoid import-time blocking of Streamlit startup. 
- Confirmed deployment configuration: `app/streamlit_app.py` is the entrypoint, `requirements.txt` uses `.` (no `-e`) and `runtime.txt` pins Python 3.10.x, so no runtime dependencies were added.

### Testing
- Ran `python -m compileall .` which completed successfully and produced bytecode for all modules. 
- Verified the package import with `python -c "import mdl; print('mdl ok')"` which returned `mdl ok` after installing the local package; initial `pip install .` failed in this environment due to build-isolation/proxy issues but succeeded when run with `--no-build-isolation` for local verification. 
- Launched `streamlit run app/streamlit_app.py --server.headless true --server.port 8501` and confirmed the server started, the HTML shell replied to `curl`, and the console log contained `Startup OK`; a browser screenshot of the first page load was captured. 
- No automated behavior tests were modified; changes are startup/diagnostic-only and all actions succeeded for local verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987c0e53b788328b96a07c7fd02d973)