### PR TITLE
Streamlit UX: Advanced controls, OHLCV retry + disk cache, and friendlier error handling

### DIFF
--- a/tests/test_ohlcv_resilience.py
+++ b/tests/test_ohlcv_resilience.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from mdl.data.ohlcv import fetch_with_retries, _cache_path
+
+
+def test_fetch_with_retries_retries_then_succeeds() -> None:
+    attempts = {"count": 0}
+
+    def flaky() -> list:
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise TimeoutError("temporary")
+        return [1]
+
+    out = fetch_with_retries(
+        flaky,
+        max_retries=3,
+        backoff_s=0,
+        is_retryable_exception=lambda exc: isinstance(exc, TimeoutError),
+    )
+
+    assert out == [1]
+    assert attempts["count"] == 3
+
+
+def test_fetch_with_retries_raises_on_non_retryable() -> None:
+    def bad() -> list:
+        raise ValueError("invalid")
+
+    try:
+        fetch_with_retries(
+            bad,
+            max_retries=3,
+            backoff_s=0,
+            is_retryable_exception=lambda exc: isinstance(exc, TimeoutError),
+        )
+    except ValueError as exc:
+        assert str(exc) == "invalid"
+    else:
+        raise AssertionError("Expected ValueError")
+
+
+def test_cache_path_layout() -> None:
+    path = _cache_path("kraken", "BTC/USDT", "1h", 30)
+    assert str(path).endswith(".cache/ohlcv/kraken/BTC-USDT/1h/30.parquet")


### PR DESCRIPTION
### Motivation
- Improve UI resilience when exchanges rate-limit or network calls fail and give users clear, actionable feedback. 
- Provide safe, optional controls for caching and retries so users can reduce API pressure without changing decision outputs. 
- Avoid uncaught tracebacks in the Streamlit UI while keeping all scenario/decision logic unchanged.

### Description
- Added an Advanced sidebar panel with controls: `Use cached data when available` (default ON), `Show debug details` (default OFF), `Max retries` [0,1,2,3] (default 1), and `Retry backoff (seconds)` [0,1,2,5] (default 1), and wired these options into the fetch path without cross-layer imports. (app/streamlit_app.py)
- Implemented `fetch_with_retries(fn, max_retries, backoff_s, is_retryable_exception)` in `src/mdl/data/ohlcv.py` and added optional `use_cache`, `max_retries`, and `backoff_s` parameters to `fetch_ohlcv(...)` so retry/backoff behavior is configurable and safe. (src/mdl/data/ohlcv.py)
- Added a simple deterministic disk cache for OHLCV at `.cache/ohlcv/{exchange}/{symbol}/{timeframe}/{days}.parquet` with a 30-minute TTL and read/write helpers that do not alter fetched data. (src/mdl/data/ohlcv.py)
- Improved UI error handling for Quick/Compare flows to catch ccxt rate-limit / DDoS / RequestTimeout / NetworkError exceptions, show a friendly `st.error` guidance message, and expose the raw exception as a `st.caption` with traceback only when `Show debug details` is enabled. This prevents uncaught tracebacks in the UI. (app/streamlit_app.py)
- Added a compact “Inputs summary” displayed before Quick and Compare results so users immediately see exchange, symbol, timeframe(s), days, and scenario count. (app/streamlit_app.py)
- Kept all scenario and decision computation logic unchanged and passed advanced options through existing call paths using optional parameters so public API behavior is preserved.
- Added unit tests for the retry wrapper and cache path layout. (tests/test_ohlcv_resilience.py)

### Testing
- Compiled key modules with `python -m py_compile app/streamlit_app.py src/mdl/data/ohlcv.py src/mdl/scenarios.py` which completed successfully. 
- Ran the test suite with the package import path set via `PYTHONPATH=src pytest -q` and received `5 passed`. 
- Performed a quick Streamlit smoke run with `PYTHONPATH=src streamlit run app/streamlit_app.py --server.headless true --server.port 8501` to validate UI startup and captured a screenshot of the updated UI (server started successfully during the smoke check).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987c8a184548328b395a2ad1b16ef88)