### PR TITLE
CI: Install pytest and run tests with `python -m pytest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Install test dependencies
+        run: pip install pytest
+
       - name: Run tests
-        run: pytest
+        run: python -m pytest


### PR DESCRIPTION
### Motivation
- CI was failing with `pytest: command not found` after installing `requirements.txt`, so the workflow needs to ensure the test runner is available and invoked reliably.

### Description
- Added an `Install test dependencies` step running `pip install pytest` in `.github/workflows/ci.yml` immediately after `pip install -r requirements.txt`.
- Replaced the bare `pytest` invocation with `python -m pytest` to avoid relying on a directly available `pytest` executable.
- No changes were made to application runtime dependencies.

### Testing
- Ran `python -m pytest` locally and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698852b2900c8328b777294faad67bb3)