### PR TITLE
Sidebar Actions UX, UI guards, compare logging fix, and tests

### DIFF
--- a/app/ui_guards.py
+++ b/app/ui_guards.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+COMPARE_DAY_CAP_1H = 41
+
+
+def validate_timeframe_for_exchange(exchange: str, timeframe: str) -> tuple[bool, str | None]:
+    """Validate exchange/timeframe combinations exposed in the UI."""
+    if exchange == "coinbase" and timeframe == "4h":
+        return False, "Coinbase does not support 4h candles in this app. Choose 1h or 1d."
+    return True, None
+
+
+def can_run_compare(inputs: dict[str, Any]) -> tuple[bool, str | None]:
+    """Validate compare-specific limits before starting a run."""
+    days = int(inputs.get("days", 0))
+    if days > COMPARE_DAY_CAP_1H:
+        return False, f"Compare supports up to {COMPARE_DAY_CAP_1H} days because it includes 1h candles."
+    return True, None
+
+
+def can_run_strategy_lab(state: dict[str, Any]) -> tuple[bool, str | None]:
+    """Require existing run context before strategy lab can be launched."""
+    has_quick = state.get("quick_result") is not None
+    has_compare = state.get("compare_result") is not None
+    if not (has_quick or has_compare):
+        return False, "Run Quick Check or A/B/C Compare first to provide data context for Strategy Lab."
+    return True, None

--- a/src/mdl/logging_helpers.py
+++ b/src/mdl/logging_helpers.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
+SCENARIO_KEYS = ("A", "B", "C")
+
+
+def extract_scenario_metrics(scenarios: dict[str, Any]) -> dict[str, Any]:
+    """Return metrics only for scenario keys A/B/C when present."""
+    filtered: dict[str, Any] = {}
+    for key in SCENARIO_KEYS:
+        value = scenarios.get(key)
+        if isinstance(value, dict) and isinstance(value.get("metrics"), dict):
+            filtered[key] = value["metrics"]
+    return filtered

--- a/tests/test_logging_helpers.py
+++ b/tests/test_logging_helpers.py
@@ -1,0 +1,19 @@
+from mdl.logging_helpers import extract_scenario_metrics
+
+
+def test_extract_scenario_metrics_filters_non_scenarios() -> None:
+    scenarios = {
+        "A": {"metrics": {"Annualized Return %": 1.2}},
+        "B": {"metrics": {"Annualized Return %": 2.3}},
+        "C": {"metrics": {"Annualized Return %": 3.4}},
+        "all_candidates": ["x", "y"],
+        "meta": {"count": 3},
+    }
+
+    metrics = extract_scenario_metrics(scenarios)
+
+    assert metrics == {
+        "A": {"Annualized Return %": 1.2},
+        "B": {"Annualized Return %": 2.3},
+        "C": {"Annualized Return %": 3.4},
+    }

--- a/tests/test_ui_guards.py
+++ b/tests/test_ui_guards.py
@@ -1,0 +1,34 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "app" / "ui_guards.py"
+SPEC = importlib.util.spec_from_file_location("ui_guards", MODULE_PATH)
+ui_guards = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(ui_guards)
+
+
+validate_timeframe_for_exchange = ui_guards.validate_timeframe_for_exchange
+can_run_compare = ui_guards.can_run_compare
+can_run_strategy_lab = ui_guards.can_run_strategy_lab
+
+
+def test_validate_timeframe_for_exchange_blocks_coinbase_4h() -> None:
+    ok, msg = validate_timeframe_for_exchange("coinbase", "4h")
+
+    assert ok is False
+    assert msg is not None
+
+
+def test_can_run_compare_blocks_days_over_cap() -> None:
+    ok, msg = can_run_compare({"days": 42})
+
+    assert ok is False
+    assert "41" in (msg or "")
+
+
+def test_can_run_strategy_lab_blocks_without_prior_results() -> None:
+    ok, msg = can_run_strategy_lab({"quick_result": None, "compare_result": None})
+
+    assert ok is False
+    assert msg is not None


### PR DESCRIPTION
### Motivation
- Remove modal "Mode" gating so users can run Quick / Compare / Strategy Lab from sidebar buttons without switching blocks.
- Provide clear UI guards and messages when an action cannot run instead of disabled controls or tracebacks.
- Prevent a post-run crash when logging compare metrics by avoiding blind iteration over non-scenario keys.

### Description
- Reworked the sidebar in `app/streamlit_app.py` to remove the `Mode` selectbox and disabled logic and add an `Actions` section with buttons `▶ Run Quick Check`, `▶▶ Run A/B/C Compare`, and `🧪 Run Strategy Lab (Auto)` plus an `Advanced → ♻ Reset session` button that clears run results and reruns while preserving inputs.
- Added `app/ui_guards.py` with `validate_timeframe_for_exchange`, `can_run_compare`, and `can_run_strategy_lab` and integrated these guards into the sidebar and action handlers to display user-friendly `st.caption`/`st.info` messages when runs are blocked.
- Added `src/mdl/logging_helpers.py` with `extract_scenario_metrics` and used it in `app/streamlit_app.py` to ensure only A/B/C scenario metrics are logged, preventing the `list indices must be integers or slices, not str` crash when `scenarios` contains non-scenario keys like `all_candidates`.
- Added regression tests `tests/test_logging_helpers.py` and `tests/test_ui_guards.py` to validate scenario-metrics extraction and UI guard behavior.

### Testing
- Ran `python -m compileall app src` to verify modules compile successfully (succeeded).
- Ran unit tests with `pytest -q` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a06f325c8328966ee1442de000c1)