### PR TITLE
improve: decision weights, scenario reasons, parallel backtests, walk-forward validation

### DIFF
--- a/src/mdl/backtest/metrics.py
+++ b/src/mdl/backtest/metrics.py
@@ -54,3 +54,56 @@ def summarize_metrics(backtest_df: pd.DataFrame, trades_df: pd.DataFrame, initia
         "Profit Factor": float(profit_factor) if math.isfinite(profit_factor) else math.inf,
         "Test Days": int(test_days),
     }
+
+
+def walk_forward_score(ohlcv_df: pd.DataFrame, params, initial_cash: float) -> dict:
+    """Split OHLCV data 70/30, backtest each portion, and assess out-of-sample robustness.
+
+    Args:
+        ohlcv_df: Full OHLCV DataFrame with a ``ts`` column.
+        params: ``BacktestParams`` instance used for both backtest runs.
+        initial_cash: Starting capital for both backtest runs.
+
+    Returns:
+        Dict with keys:
+            ``in_sample``     – metrics dict for the first 70 % of data.
+            ``out_of_sample`` – metrics dict for the remaining 30 % of data.
+            ``is_robust``     – True when the out-of-sample run is profitable
+                                and its drawdown does not exceed 1.5× the
+                                in-sample drawdown.
+    """
+    from mdl.backtest.engine import run_backtest  # local import avoids circular dependency
+
+    if ohlcv_df.empty:
+        raise ValueError("ohlcv_df is empty; cannot run walk-forward split.")
+
+    n = len(ohlcv_df)
+    split = max(1, int(n * 0.7))
+
+    in_df = ohlcv_df.iloc[:split].reset_index(drop=True)
+    out_df = ohlcv_df.iloc[split:].reset_index(drop=True)
+
+    def _days(df: pd.DataFrame) -> int:
+        if "ts" in df.columns and len(df) >= 2:
+            delta = pd.to_datetime(df["ts"].iloc[-1]) - pd.to_datetime(df["ts"].iloc[0])
+            return max(1, int(delta.total_seconds() / 86400))
+        return max(1, len(df))
+
+    in_bt, in_tr = run_backtest(in_df, params)
+    out_bt, out_tr = run_backtest(out_df, params)
+
+    in_metrics = summarize_metrics(in_bt, in_tr, initial_cash=initial_cash, test_days=_days(in_df))
+    out_metrics = summarize_metrics(out_bt, out_tr, initial_cash=initial_cash, test_days=_days(out_df))
+
+    in_dd = in_metrics["Max Drawdown %"]
+    out_dd = out_metrics["Max Drawdown %"]
+    is_robust = (
+        out_metrics["Annualized Return %"] > 0
+        and out_dd <= max(in_dd * 1.5, 1.0)  # allow slight degradation but not runaway drawdown
+    )
+
+    return {
+        "in_sample": in_metrics,
+        "out_of_sample": out_metrics,
+        "is_robust": is_robust,
+    }

--- a/src/mdl/config.py
+++ b/src/mdl/config.py
@@ -7,3 +7,9 @@ DD_MAX = 25
 MIN_TRADES = 12
 TPW_TARGET = 2
 TPW_TOL = 1
+
+# Decision score weights used in _decision_score()
+W_RET = 1.0   # weight for annualized return contribution (higher = better)
+W_DD = 0.8    # weight for max drawdown penalty (higher = penalises risk more)
+W_TPW = 0.1   # weight for trades-per-week deviation penalty
+W_EXP = 0.2   # weight for per-trade expectancy contribution

--- a/src/mdl/decision.py
+++ b/src/mdl/decision.py
@@ -30,7 +30,7 @@ def _decision_score(metrics: dict) -> float:
     tpw_pen = abs(tpw - config.TPW_TARGET) / max(config.TPW_TARGET, 1e-9)
     exp_s = exp / 1.0
 
-    return (1.0 * ann_s) - (0.8 * dd_s) - (0.1 * tpw_pen) + (0.2 * exp_s)
+    return (config.W_RET * ann_s) - (config.W_DD * dd_s) - (config.W_TPW * tpw_pen) + (config.W_EXP * exp_s)
 
 
 def evaluate_run(metrics: dict) -> dict:
@@ -82,6 +82,14 @@ def evaluate_run(metrics: dict) -> dict:
 
 
 def final_decision(scenarios_dict: dict) -> dict:
+    if not scenarios_dict:
+        return {
+            "label": "NO",
+            "text": "NO - no scenarios provided.",
+            "recommended": None,
+            "reason": "Empty scenarios input; nothing to evaluate.",
+        }
+
     statuses = {k: v["decision"]["status"] for k, v in scenarios_dict.items()}
     all_red = all(s == "RED" for s in statuses.values())
 
@@ -103,9 +111,24 @@ def final_decision(scenarios_dict: dict) -> dict:
             )[0][0]
 
     if all_red:
-        return {"label": "NO", "text": "NO - all scenarios are high-risk or underperforming.", "recommended": recommended}
+        return {
+            "label": "NO",
+            "text": "NO - all scenarios are high-risk or underperforming.",
+            "recommended": recommended,
+            "reason": "Every scenario breached a hard risk limit or produced negative returns.",
+        }
 
     if any(s == "GREEN" for s in statuses.values()) and statuses.get(recommended) != "RED":
-        return {"label": "INVEST", "text": "INVEST - at least one scenario is robust with acceptable risk.", "recommended": recommended}
+        return {
+            "label": "INVEST",
+            "text": "INVEST - at least one scenario is robust with acceptable risk.",
+            "recommended": recommended,
+            "reason": f"Scenario {recommended} passed all return and drawdown thresholds.",
+        }
 
-    return {"label": "CAUTION", "text": "CAUTION - no fully robust setup; proceed only with risk controls.", "recommended": recommended}
+    return {
+        "label": "CAUTION",
+        "text": "CAUTION - no fully robust setup; proceed only with risk controls.",
+        "recommended": recommended,
+        "reason": f"Scenario {recommended} has the best score but did not reach GREEN status.",
+    }

--- a/src/mdl/scenarios.py
+++ b/src/mdl/scenarios.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from itertools import product
 from typing import Any
@@ -36,10 +37,10 @@ def run_scenarios(
 ) -> dict:
     """Run scenario sweep with injectable OHLCV fetcher to support UI-level caching."""
     base_params = base_params or {}
-    candidates = []
     timeframe_data = {timeframe: ohlcv_fetcher(exchange, symbol, timeframe, days) for timeframe in ["1h", "4h", "1d"]}
 
-    for timeframe, ema_window, signal_mode in product(["1h", "4h", "1d"], [20, 50], ["strict", "relaxed"]):
+    def _run_combination(combo: tuple) -> dict:
+        timeframe, ema_window, signal_mode = combo
         ohlcv_df = timeframe_data[timeframe]
         params = BacktestParams(
             ema_window=ema_window,
@@ -51,20 +52,21 @@ def run_scenarios(
             slippage_per_side=float(base_params.get("slippage_per_side", 0.0002)),
             initial_cash=float(initial_cash),
         )
-
         bt_df, tr_df = run_backtest(ohlcv_df, params)
         metrics = summarize_metrics(bt_df, tr_df, initial_cash=initial_cash, test_days=days)
         decision = evaluate_run(metrics)
-        candidates.append(
-            {
-                "params": {**asdict(params), "timeframe": timeframe},
-                "backtest_df": bt_df,
-                "trades_df": tr_df,
-                "metrics": metrics,
-                "decision": decision,
-                "risk_exceeded": metrics["Max Drawdown %"] > DD_MAX,
-            }
-        )
+        return {
+            "params": {**asdict(params), "timeframe": timeframe},
+            "backtest_df": bt_df,
+            "trades_df": tr_df,
+            "metrics": metrics,
+            "decision": decision,
+            "risk_exceeded": metrics["Max Drawdown %"] > DD_MAX,
+        }
+
+    combos = list(product(["1h", "4h", "1d"], [20, 50], ["strict", "relaxed"]))
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        candidates = list(executor.map(_run_combination, combos))
 
     if not candidates:
         raise ValueError("No scenarios generated - check data availability")
@@ -96,6 +98,7 @@ def run_scenarios(
                 -abs(c["metrics"]["Trades Per Week"] - TPW_TARGET),
             ),
         )
+    scenario_a["selection_reason"] = "Best expectancy with balanced risk (highest Expectancy %, lowest drawdown, closest trade frequency to target)."
     used.add(sig(scenario_a))
 
     # Scenario B: Best return within risk limits
@@ -110,6 +113,11 @@ def run_scenarios(
             # Fallback: reuse a scenario if all are used
             scenario_b = _select_best(candidates, key=lambda c: c["metrics"]["Annualized Return %"])
         scenario_b["risk_exceeded"] = True
+    scenario_b["selection_reason"] = (
+        "Best return within risk limits (highest Annualized Return % with Max Drawdown % <= DD_MAX)."
+        if not scenario_b.get("risk_exceeded")
+        else "Best return available; note: drawdown exceeds risk limit."
+    )
     used.add(sig(scenario_b))
 
     # Scenario C: Most stable/consistent
@@ -119,6 +127,7 @@ def run_scenarios(
     else:
         # Fallback: reuse a scenario if all are used
         scenario_c = _select_best(candidates, key=lambda c: _stability_score(c["metrics"]))
+    scenario_c["selection_reason"] = "Most stable/consistent (highest stability score: lowest drawdown and closest trade frequency to target)."
     used.add(sig(scenario_c))
 
     return {"A": scenario_a, "B": scenario_b, "C": scenario_c, "all_candidates": candidates}


### PR DESCRIPTION
## Summary

- **`config.py`** – Add four named weight constants (`W_RET=1.0`, `W_DD=0.8`, `W_TPW=0.1`, `W_EXP=0.2`) with inline comments explaining each weight's role in the decision score formula.
- **`decision.py`** – Replace hard-coded literals in `_decision_score()` with the new config constants; add a `reason` field to every `final_decision()` return value so callers get a human-readable explanation; guard `final_decision()` against an empty `scenarios_dict` input.
- **`scenarios.py`** – Replace the sequential backtest loop with `ThreadPoolExecutor(max_workers=6)` so all 12 parameter combinations run in parallel; add a `selection_reason` string to each scenario A/B/C describing the criterion used to select it.
- **`metrics.py`** – Add `walk_forward_score(ohlcv_df, params, initial_cash)`: splits data 70/30, runs `run_backtest` on each portion, calls `summarize_metrics` for both, and returns `{in_sample, out_of_sample, is_robust}` where `is_robust` is True when the out-of-sample run is profitable and its drawdown stays within 1.5× the in-sample drawdown.

## Test plan

- [ ] `walk_forward_score` returns correct keys (`in_sample`, `out_of_sample`, `is_robust`) and `is_robust` flips correctly with synthetic data
- [ ] `final_decision({})` returns `label="NO"` with `reason` field and does not raise
- [ ] `final_decision` returns `reason` field in all three branches (NO/INVEST/CAUTION)
- [ ] `_decision_score` produces identical values to the old hard-coded formula (weights unchanged)
- [ ] Each scenario dict contains `selection_reason` key after `run_scenarios`
- [ ] Parallel scenario sweep produces the same candidate set as the serial version

🤖 Generated with [Claude Code](https://claude.com/claude-code)